### PR TITLE
Clarify success message when cache is successfully cleared

### DIFF
--- a/features/cache.feature
+++ b/features/cache.feature
@@ -27,7 +27,7 @@ Feature: Manage oEmbed cache.
     When I run `wp embed cache clear 1`
     Then STDOUT should be:
       """
-      Success: Successfully cleared oEmbed cache for post 1
+      Success: Cleared oEmbed cache.
       """
 
   Scenario: Trigger oEmbed cache for a non-existent post

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -41,7 +41,7 @@ class Cache_Command extends WP_CLI_Command {
 
 		$wp_embed->delete_oembed_caches( $post_id );
 
-		WP_CLI::success( sprintf( 'Successfully cleared oEmbed cache for post %d', $post_id ) );
+		WP_CLI::success( 'Cleared oEmbed cache.' );
 	}
 
 	/**


### PR DESCRIPTION
* "Successfully" is redundant in a success message.
* WP-CLI doesn't typically repeat input back to the user.