### PR TITLE
Bail early in cache find command for WordPress < 4.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ Finds the oEmbed cache post ID for a given URL.
 wp embed cache find <url> [--width=<width>] [--height=<height>]
 ~~~
 
-Starts by checking the URL against the regex of the registered embed handlers.
-If none of the regex matches and it's enabled, then the URL will be given to the WP_oEmbed class.
+Starting with WordPress 4.9, embeds that aren't associated with a specific post will be cached in
+a new oembed_cache post type.
 
 **OPTIONS**
 

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -50,6 +50,7 @@ Feature: Manage oEmbed cache.
       """
     And the return code should be 0
 
+  @require-wp-4.9
   Scenario: Find oEmbed cache post ID for a non-existent key
     When I try `wp embed cache find foo`
     Then STDERR should be:
@@ -58,6 +59,7 @@ Feature: Manage oEmbed cache.
       """
     And the return code should be 1
 
+  @require-wp-4.9
   Scenario: Find oEmbed cache post ID for an existing key
     When I run `wp eval 'echo md5( "foo" . serialize( array( "width" => 600, "height" => 400 ) ) );'`
     Then STDOUT should not be empty

--- a/features/handler.feature
+++ b/features/handler.feature
@@ -3,6 +3,8 @@ Feature: Manage embed handlers.
   Background:
     Given a WP install
 
+  # See https://core.trac.wordpress.org/changeset/37744
+  @require-wp-4.6
   Scenario: List embed handlers
     When I run `wp embed handler list --fields=priority,id`
     Then STDOUT should be a table containing rows:

--- a/features/provider.feature
+++ b/features/provider.feature
@@ -3,6 +3,7 @@ Feature: Manage oEmbed providers.
   Background:
     Given a WP install
 
+  @require-wp-4.9
   Scenario: List oEmbed providers
     When I run `wp embed provider list --fields=format,endpoint`
     Then STDOUT should be a table containing rows:

--- a/features/provider.feature
+++ b/features/provider.feature
@@ -3,82 +3,45 @@ Feature: Manage oEmbed providers.
   Background:
     Given a WP install
 
-  @require-wp-4.9
   Scenario: List oEmbed providers
     When I run `wp embed provider list --fields=format,endpoint`
-    Then STDOUT should be a table containing rows:
-      | format                                                                     | endpoint                                                              |
-      | #https?://((m\|www)\.)?youtube\.com/watch.*#i                              | https://www.youtube.com/oembed                                        |
-      | #https?://((m\|www)\.)?youtube\.com/playlist.*#i                           | https://www.youtube.com/oembed                                        |
-      | #https?://youtu\.be/.*#i                                                   | https://www.youtube.com/oembed                                        |
-      | #https?://(.+\.)?vimeo\.com/.*#i                                           | https://vimeo.com/api/oembed.{format}                                 |
-      | #https?://(www\.)?dailymotion\.com/.*#i                                    | https://www.dailymotion.com/services/oembed                           |
-      | #https?://dai\.ly/.*#i                                                     | https://www.dailymotion.com/services/oembed                           |
-      | #https?://(www\.)?flickr\.com/.*#i                                         | https://www.flickr.com/services/oembed/                               |
-      | #https?://flic\.kr/.*#i                                                    | https://www.flickr.com/services/oembed/                               |
-      | #https?://(.+\.)?smugmug\.com/.*#i                                         | https://api.smugmug.com/services/oembed/                              |
-      | #https?://(www\.)?hulu\.com/watch/.*#i                                     | http://www.hulu.com/api/oembed.{format}                               |
-      | http://i*.photobucket.com/albums/*                                         | http://api.photobucket.com/oembed                                     |
-      | http://gi*.photobucket.com/groups/*                                        | http://api.photobucket.com/oembed                                     |
-      | #https?://(www\.)?scribd\.com/doc/.*#i                                     | https://www.scribd.com/services/oembed                                |
-      | #https?://wordpress\.tv/.*#i                                               | https://wordpress.tv/oembed/                                          |
-      | #https?://(.+\.)?polldaddy\.com/.*#i                                       | https://polldaddy.com/oembed/                                         |
-      | #https?://poll\.fm/.*#i                                                    | https://polldaddy.com/oembed/                                         |
-      | #https?://(www\.)?funnyordie\.com/videos/.*#i                              | http://www.funnyordie.com/oembed                                      |
-      | #https?://(www\.)?twitter\.com/\w{1,15}/status(es)?/.*#i                   | https://publish.twitter.com/oembed                                    |
-      | #https?://(www\.)?twitter\.com/\w{1,15}$#i                                 | https://publish.twitter.com/oembed                                    |
-      | #https?://(www\.)?twitter\.com/\w{1,15}/likes$#i                           | https://publish.twitter.com/oembed                                    |
-      | #https?://(www\.)?twitter\.com/\w{1,15}/lists/.*#i                         | https://publish.twitter.com/oembed                                    |
-      | #https?://(www\.)?twitter\.com/\w{1,15}/timelines/.*#i                     | https://publish.twitter.com/oembed                                    |
-      | #https?://(www\.)?twitter\.com/i/moments/.*#i                              | https://publish.twitter.com/oembed                                    |
-      | #https?://(www\.)?soundcloud\.com/.*#i                                     | https://soundcloud.com/oembed                                         |
-      | #https?://(.+?\.)?slideshare\.net/.*#i                                     | https://www.slideshare.net/api/oembed/2                               |
-      | #https?://(www\.)?instagr(\.am\|am\.com)/p/.*#i                            | https://api.instagram.com/oembed                                      |
-      | #https?://(open\|play)\.spotify\.com/.*#i                                  | https://embed.spotify.com/oembed/                                     |
-      | #https?://(.+\.)?imgur\.com/.*#i                                           | https://api.imgur.com/oembed                                          |
-      | #https?://(www\.)?meetu(\.ps\|p\.com)/.*#i                                 | https://api.meetup.com/oembed                                         |
-      | #https?://(www\.)?issuu\.com/.+/docs/.+#i                                  | https://issuu.com/oembed_wp                                           |
-      | #https?://(www\.)?collegehumor\.com/video/.*#i                             | https://www.collegehumor.com/oembed.{format}                          |
-      | #https?://(www\.)?mixcloud\.com/.*#i                                       | https://www.mixcloud.com/oembed                                       |
-      | #https?://(www\.\|embed\.)?ted\.com/talks/.*#i                             | https://www.ted.com/services/v1/oembed.{format}                       |
-      | #https?://(www\.)?(animoto\|video214)\.com/play/.*#i                       | https://animoto.com/oembeds/create                                    |
-      | #https?://(.+)\.tumblr\.com/post/.*#i                                      | https://www.tumblr.com/oembed/1.0                                     |
-      | #https?://(www\.)?kickstarter\.com/projects/.*#i                           | https://www.kickstarter.com/services/oembed                           |
-      | #https?://kck\.st/.*#i                                                     | https://www.kickstarter.com/services/oembed                           |
-      | #https?://cloudup\.com/.*#i                                                | https://cloudup.com/oembed                                            |
-      | #https?://(www\.)?reverbnation\.com/.*#i                                   | https://www.reverbnation.com/oembed                                   |
-      | #https?://videopress\.com/v/.*#                                            | https://public-api.wordpress.com/oembed/?for=http%3A%2F%2Fexample.com |
-      | #https?://(www\.)?reddit\.com/r/[^/]+/comments/.*#i                        | https://www.reddit.com/oembed                                         |
-      | #https?://(www\.)?speakerdeck\.com/.*#i                                    | https://speakerdeck.com/oembed.{format}                               |
-      | #https?://www\.facebook\.com/.*/posts/.*#i                                 | https://www.facebook.com/plugins/post/oembed.json/                    |
-      | #https?://www\.facebook\.com/.*/activity/.*#i                              | https://www.facebook.com/plugins/post/oembed.json/                    |
-      | #https?://www\.facebook\.com/.*/photos/.*#i                                | https://www.facebook.com/plugins/post/oembed.json/                    |
-      | #https?://www\.facebook\.com/photo(s/\|\.php).*#i                          | https://www.facebook.com/plugins/post/oembed.json/                    |
-      | #https?://www\.facebook\.com/permalink\.php.*#i                            | https://www.facebook.com/plugins/post/oembed.json/                    |
-      | #https?://www\.facebook\.com/media/.*#i                                    | https://www.facebook.com/plugins/post/oembed.json/                    |
-      | #https?://www\.facebook\.com/questions/.*#i                                | https://www.facebook.com/plugins/post/oembed.json/                    |
-      | #https?://www\.facebook\.com/notes/.*#i                                    | https://www.facebook.com/plugins/post/oembed.json/                    |
-      | #https?://www\.facebook\.com/.*/videos/.*#i                                | https://www.facebook.com/plugins/video/oembed.json/                   |
-      | #https?://www\.facebook\.com/video\.php.*#i                                | https://www.facebook.com/plugins/video/oembed.json/                   |
-      | #https?://(www\.)?screencast\.com/.*#i                                     | https://api.screencast.com/external/oembed                            |
-      | #https?://([a-z0-9-]+\.)?amazon\.(com\|com\.mx\|com\.br\|ca)/.*#i          | https://read.amazon.com/kp/api/oembed                                 |
-      | #https?://([a-z0-9-]+\.)?amazon\.(co\.uk\|de\|fr\|it\|es\|in\|nl\|ru)/.*#i | https://read.amazon.co.uk/kp/api/oembed                               |
-      | #https?://([a-z0-9-]+\.)?amazon\.(co\.jp\|com\.au)/.*#i                    | https://read.amazon.com.au/kp/api/oembed                              |
-      | #https?://([a-z0-9-]+\.)?amazon\.cn/.*#i                                   | https://read.amazon.cn/kp/api/oembed                                  |
-      | #https?://(www\.)?a\.co/.*#i                                               | https://read.amazon.com/kp/api/oembed                                 |
-      | #https?://(www\.)?amzn\.to/.*#i                                            | https://read.amazon.com/kp/api/oembed                                 |
-      | #https?://(www\.)?amzn\.eu/.*#i                                            | https://read.amazon.co.uk/kp/api/oembed                               |
-      | #https?://(www\.)?amzn\.in/.*#i                                            | https://read.amazon.in/kp/api/oembed                                  |
-      | #https?://(www\.)?amzn\.asia/.*#i                                          | https://read.amazon.com.au/kp/api/oembed                              |
-      | #https?://(www\.)?z\.cn/.*#i                                               | https://read.amazon.cn/kp/api/oembed                                  |
-      | #https?://www\.someecards\.com/.+-cards/.+#i                               | https://www.someecards.com/v2/oembed/                                 |
-      | #https?://www\.someecards\.com/usercards/viewcard/.+#i                     | https://www.someecards.com/v2/oembed/                                 |
-      | #https?://some\.ly\/.+#i                                                   | https://www.someecards.com/v2/oembed/                                 |
+    Then STDOUT should contain:
+      """
+      youtube\.com/watch.*
+      """
+    And STDOUT should contain:
+      """
+      //www.youtube.com/oembed
+      """
+    And STDOUT should contain:
+      """
+      flickr\.com/
+      """
+    And STDOUT should contain:
+      """
+      flickr.com
+      """
+    And STDOUT should contain:
+      """
+      twitter\.com/
+      """
+    And STDOUT should contain:
+      """
+      twitter.com
+      """
+    And STDOUT should contain:
+      """
+      \.spotify\.com/
+      """
+    And STDOUT should contain:
+      """
+      spotify.com
+      """
 
   Scenario: Get an oEmbed provider
     When I run `wp embed provider get https://www.youtube.com/watch?v=dQw4w9WgXcQ`
-    And STDOUT should be:
+    And STDOUT should contain:
       """
-      https://www.youtube.com/oembed
+      //www.youtube.com/oembed
       """
     And STDERR should be empty

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -48,8 +48,8 @@ class Cache_Command extends WP_CLI_Command {
 	/**
 	 * Finds the oEmbed cache post ID for a given URL.
 	 *
-	 * Starts by checking the URL against the regex of the registered embed handlers.
-	 * If none of the regex matches and it's enabled, then the URL will be given to the WP_oEmbed class.
+	 * Starting with WordPress 4.9, embeds that aren't associated with a specific post will be cached in
+	 * a new oembed_cache post type.
 	 *
 	 * ## OPTIONS
 	 *

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -68,6 +68,10 @@ class Cache_Command extends WP_CLI_Command {
 	 *     $ wp embed cache find https://www.youtube.com/watch?v=dQw4w9WgXcQ --width=500
 	 */
 	public function find( $args, $assoc_args ) {
+		if ( Utils\wp_version_compare( '4.9', '<' ) ) {
+			WP_CLI::error( 'Requires WordPress 4.9 or greater.' );
+		}
+
 		/** @var \WP_Embed $wp_embed */
 		global $wp_embed;
 

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -91,7 +91,7 @@ class Fetch_Command extends WP_CLI_Command {
 			remove_filter( 'pre_oembed_result', 'wp_filter_pre_oembed_result' );
 			add_filter( 'pre_oembed_result', array( $this, 'filter_pre_oembed_result' ), 10, 3 );
 
-			$oembed = _wp_oembed_get_object();
+			$oembed = \_wp_oembed_get_object();
 
 			$provider = $oembed->get_provider( $url, $oembed_args );
 
@@ -217,7 +217,7 @@ class Fetch_Command extends WP_CLI_Command {
 		$width = isset( $args['width'] ) ? $args['width'] : 0;
 
 		$data = get_oembed_response_data( $post_id, $width );
-		// $data = _wp_oembed_get_object()->data2html( (object) $data, $url );
+		// $data = \_wp_oembed_get_object()->data2html( (object) $data, $url );
 
 		if ( $switched_blog ) {
 			restore_current_blog();

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -88,14 +88,11 @@ class Fetch_Command extends WP_CLI_Command {
 
 		// WP_Embed::shortcode() can't return raw data, which means we need to use WP_oEmbed.
 		if ( $raw ) {
-			if ( ! function_exists( '_wp_oembed_get_object' ) ) {
-				require_once ABSPATH . WPINC . '/class-oembed.php';
-			}
 
 			remove_filter( 'pre_oembed_result', 'wp_filter_pre_oembed_result' );
 			add_filter( 'pre_oembed_result', array( $this, 'filter_pre_oembed_result' ), 10, 3 );
 
-			$oembed = \_wp_oembed_get_object();
+			$oembed = new oEmbed;
 
 			$provider = $oembed->get_provider( $url, $oembed_args );
 

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -88,6 +88,10 @@ class Fetch_Command extends WP_CLI_Command {
 
 		// WP_Embed::shortcode() can't return raw data, which means we need to use WP_oEmbed.
 		if ( $raw ) {
+			if ( ! function_exists( '_wp_oembed_get_object' ) ) {
+				require_once ABSPATH . WPINC . '/class-oembed.php';
+			}
+
 			remove_filter( 'pre_oembed_result', 'wp_filter_pre_oembed_result' );
 			add_filter( 'pre_oembed_result', array( $this, 'filter_pre_oembed_result' ), 10, 3 );
 

--- a/src/Provider_Command.php
+++ b/src/Provider_Command.php
@@ -67,11 +67,8 @@ class Provider_Command extends WP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function list_providers( $args, $assoc_args ) {
-		if ( ! function_exists( '_wp_oembed_get_object' ) ) {
-			require_once ABSPATH . WPINC . '/class-oembed.php';
-		}
 
-		$oembed = \_wp_oembed_get_object();
+		$oembed = new oEmbed;
 
 		$force_regex = Utils\get_flag_value( $assoc_args, 'force-regex' );
 
@@ -130,11 +127,8 @@ class Provider_Command extends WP_CLI_Command {
 	 * @subcommand get
 	 */
 	public function get_provider( $args, $assoc_args ) {
-		if ( ! function_exists( '_wp_oembed_get_object' ) ) {
-			require_once ABSPATH . WPINC . '/class-oembed.php';
-		}
 
-		$oembed = \_wp_oembed_get_object();
+		$oembed = new oEmbed;
 
 		$url                 = $args[0];
 		$discover            = \WP_CLI\Utils\get_flag_value( $assoc_args, 'discover', true );

--- a/src/Provider_Command.php
+++ b/src/Provider_Command.php
@@ -67,6 +67,10 @@ class Provider_Command extends WP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function list_providers( $args, $assoc_args ) {
+		if ( ! function_exists( '_wp_oembed_get_object' ) ) {
+			require_once ABSPATH . WPINC . '/class-oembed.php';
+		}
+
 		$oembed = \_wp_oembed_get_object();
 
 		$force_regex = Utils\get_flag_value( $assoc_args, 'force-regex' );
@@ -126,6 +130,10 @@ class Provider_Command extends WP_CLI_Command {
 	 * @subcommand get
 	 */
 	public function get_provider( $args, $assoc_args ) {
+		if ( ! function_exists( '_wp_oembed_get_object' ) ) {
+			require_once ABSPATH . WPINC . '/class-oembed.php';
+		}
+
 		$oembed = \_wp_oembed_get_object();
 
 		$url                 = $args[0];

--- a/src/Provider_Command.php
+++ b/src/Provider_Command.php
@@ -67,7 +67,7 @@ class Provider_Command extends WP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function list_providers( $args, $assoc_args ) {
-		$oembed = _wp_oembed_get_object();
+		$oembed = \_wp_oembed_get_object();
 
 		$force_regex = Utils\get_flag_value( $assoc_args, 'force-regex' );
 
@@ -126,7 +126,7 @@ class Provider_Command extends WP_CLI_Command {
 	 * @subcommand get
 	 */
 	public function get_provider( $args, $assoc_args ) {
-		$oembed = _wp_oembed_get_object();
+		$oembed = \_wp_oembed_get_object();
 
 		$url                 = $args[0];
 		$discover            = \WP_CLI\Utils\get_flag_value( $assoc_args, 'discover', true );

--- a/src/oEmbed.php
+++ b/src/oEmbed.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WP_CLI\Embeds;
+
+if ( ! class_exists( '\WP_oEmbed' ) ) {
+	require_once ABSPATH . WPINC . '/class-oembed.php';
+}
+
+/**
+ * Polyfill for older WP versions.
+ */
+class oEmbed extends \WP_oEmbed {
+
+	/**
+	 * Takes a URL and returns the corresponding oEmbed provider's URL, if there is one.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @see WP_oEmbed::discover()
+	 *
+	 * @param string        $url  The URL to the content.
+	 * @param string|array  $args Optional provider arguments.
+	 * @return false|string False on failure, otherwise the oEmbed provider URL.
+	 */
+	public function get_provider( $url, $args = '' ) {
+		if ( method_exists( 'WP_oEmbed', 'get_provider' ) ) {
+			return parent::get_provider( $url, $args );
+		}
+
+		$args = wp_parse_args( $args );
+
+		$provider = false;
+
+		if ( ! isset( $args['discover'] ) ) {
+			$args['discover'] = true;
+		}
+
+		foreach ( $this->providers as $matchmask => $data ) {
+			list( $providerurl, $regex ) = $data;
+
+			// Turn the asterisk-type provider URLs into regex
+			if ( ! $regex ) {
+				$matchmask = '#' . str_replace( '___wildcard___', '(.+)', preg_quote( str_replace( '*', '___wildcard___', $matchmask ), '#' ) ) . '#i';
+				$matchmask = preg_replace( '|^#http\\\://|', '#https?\://', $matchmask );
+			}
+
+			if ( preg_match( $matchmask, $url ) ) {
+				$provider = str_replace( '{format}', 'json', $providerurl ); // JSON is easier to deal with than XML
+				break;
+			}
+		}
+
+		if ( ! $provider && $args['discover'] ) {
+			$provider = $this->discover( $url );
+		}
+
+		return $provider;
+	}
+}


### PR DESCRIPTION
Also fixes the command's description which was previously copied from another command.

Fixes #19.