### PR TITLE
Cache review suggested changes for discussion.

### DIFF
--- a/features/cache.feature
+++ b/features/cache.feature
@@ -30,11 +30,28 @@ Feature: Manage oEmbed cache.
       Success: Cleared oEmbed cache.
       """
 
+  Scenario: Trigger and clear oEmbed cache for a post
+    When I run `wp post create --post_title=Foo --post_type=post --post_status=publish --post_content="[embed]https://www.youtube.com/watch?v=dQw4w9WgXcQ[/embed]" --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp embed cache trigger {POST_ID}`
+    Then STDOUT should be:
+      """
+      Success: Caching triggered!
+      """
+
+    When I run `wp embed cache clear {POST_ID}`
+    Then STDOUT should be:
+      """
+      Success: Cleared oEmbed cache.
+      """
+
   Scenario: Trigger oEmbed cache for a non-existent post
     When I try `wp embed cache trigger 123456`
     Then STDERR should contain:
       """
-      Post 123456 does not exist!
+      Post id '123456' not found.
       """
     And the return code should be 0
 
@@ -46,7 +63,7 @@ Feature: Manage oEmbed cache.
     When I try `wp embed cache trigger {POST_ID}`
     Then STDERR should contain:
       """
-      Cannot cache oEmbed results for revision post type
+      Cannot cache oEmbed results for 'revision' post type
       """
     And the return code should be 0
 
@@ -61,7 +78,124 @@ Feature: Manage oEmbed cache.
 
   @require-wp-4.9
   Scenario: Find oEmbed cache post ID for an existing key
-    When I run `wp eval 'echo md5( "foo" . serialize( array( "width" => 600, "height" => 400 ) ) );'`
+    # Add a non-post embed, default attributes.
+    When I run `wp eval 'echo $GLOBALS["wp_embed"]->run_shortcode( "[embed]https://www.youtube.com/watch?v=dQw4w9WgXcQ[/embed]" );'`
+    Then STDOUT should contain:
+      """
+      dQw4w9WgXcQ
+      """
+
+    When I run `wp embed cache find 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'`
+    Then STDOUT should be a number
+
+    # Add a non-post embed with width attribute.
+    When I run `wp eval 'echo $GLOBALS["wp_embed"]->run_shortcode( "[embed width=400]https://www.youtube.com/watch?v=yPYZpwSpKmA[/embed]" );'`
+    Then STDOUT should contain:
+      """
+      yPYZpwSpKmA
+      """
+
+    # Fail if width not given.
+    When I try `wp embed cache find 'https://www.youtube.com/watch?v=yPYZpwSpKmA'`
+    Then STDERR should be:
+      """
+      Error: No cache post ID found!
+      """
+    And the return code should be 1
+
+    # Succeed if correct width given.
+    When I run `wp embed cache find 'https://www.youtube.com/watch?v=yPYZpwSpKmA' --width=400`
+    Then STDOUT should be a number
+
+    # Fail if incorrect width given.
+    When I try `wp embed cache find 'https://www.youtube.com/watch?v=yPYZpwSpKmA' --width=500`
+    Then STDERR should be:
+      """
+      Error: No cache post ID found!
+      """
+    And the return code should be 1
+
+    # Add a non-post embed with discover=1 attribute.
+    When I run `wp eval 'echo $GLOBALS["wp_embed"]->run_shortcode( "[embed discover=1]https://www.youtube.com/watch?v=yBwD4iYcWC4[/embed]" );'`
+    Then STDOUT should contain:
+      """
+      yBwD4iYcWC4
+      """
+
+    # Succeed if no options given.
+    When I run `wp embed cache find 'https://www.youtube.com/watch?v=yBwD4iYcWC4'`
+    Then STDOUT should be a number
+
+    # Fail if incorrect discover given.
+    When I try `wp embed cache find 'https://www.youtube.com/watch?v=yBwD4iYcWC4' --no-discover`
+    Then STDERR should be:
+      """
+      Error: No cache post ID found!
+      """
+    And the return code should be 1
+
+    # Succeed if correct discover given.
+    When I run `wp embed cache find 'https://www.youtube.com/watch?v=yBwD4iYcWC4' --discover`
+    Then STDOUT should be a number
+
+    # Add a non-post embed with width and discover attributes.
+    When I run `wp eval 'echo $GLOBALS["wp_embed"]->run_shortcode( "[embed width=450 discover=0]https://www.youtube.com/watch?v=eYuUAGXN0KM[/embed]" );'`
+    Then STDOUT should contain:
+      """
+      eYuUAGXN0KM
+      """
+
+    # Fail if no options given.
+    When I try `wp embed cache find 'https://www.youtube.com/watch?v=eYuUAGXN0KM'`
+    Then STDERR should be:
+      """
+      Error: No cache post ID found!
+      """
+    And the return code should be 1
+
+    # Succeed if correct width given.
+    When I run `wp embed cache find 'https://www.youtube.com/watch?v=eYuUAGXN0KM' --width=450`
+    Then STDOUT should be a number
+
+    # Succeed if correct width and discover given.
+    When I run `wp embed cache find 'https://www.youtube.com/watch?v=eYuUAGXN0KM' --width=450 --no-discover`
+    Then STDOUT should be a number
+
+    # Fail if correct width and incorrect discover given.
+    When I try `wp embed cache find 'https://www.youtube.com/watch?v=eYuUAGXN0KM' --width=450 --discover`
+    Then STDERR should be:
+      """
+      Error: No cache post ID found!
+      """
+    And the return code should be 1
+
+    # Add using embed fetch. Temporarily disabled as requires embed fetch changes.
+    #When I run `wp embed fetch https://example.org/embed?1234`
+    #Then STDOUT should be:
+      #"""
+     #<a href="https://example.org/embed?1234">https://example.org/embed?1234</a>
+      #"""
+
+    #When I run `wp embed cache find https://example.org/embed?1234`
+    #Then STDOUT should be a number
+
+    # Dummy data with default width/height.
+    When I run `wp eval 'echo md5( "foo" . serialize( wp_embed_defaults() ) );'`
+    Then STDOUT should not be empty
+    And save STDOUT as {CACHE_KEY}
+
+    When I run `wp post create --post_title=Foo --post_name={CACHE_KEY} --post_type=oembed_cache --post_status=publish --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp embed cache find foo`
+    Then STDOUT should be:
+      """
+     {POST_ID}
+      """
+
+    # Dummy data with given width/height. Specify width/height as strings as that's what shortcode attributes will be passed as.
+    When I run `wp eval 'echo md5( "foo" . serialize( array( "width" => "600", "height" => "400" ) ) );'`
     Then STDOUT should not be empty
     And save STDOUT as {CACHE_KEY}
 

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -58,7 +58,7 @@ class Cache_Command extends WP_CLI_Command {
 	 * Starting with WordPress 4.9, embeds that aren't associated with a specific post will be cached in
 	 * a new oembed_cache post type. There can be more than one such entry for a url depending on attributes and context.
 	 *
-	 * Not to be confused to oEmbed caches for a given post which are stored in the post's metadata.
+	 * Not to be confused with oEmbed caches for a given post which are stored in the post's metadata.
 	 *
 	 * ## OPTIONS
 	 *

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -16,6 +16,8 @@ class Cache_Command extends WP_CLI_Command {
 	/**
 	 * Deletes all oEmbed caches for a given post.
 	 *
+	 * oEmbed caches for a post are stored in the post's metadata.
+	 *
 	 * ## OPTIONS
 	 *
 	 * <post_id>
@@ -25,6 +27,7 @@ class Cache_Command extends WP_CLI_Command {
 	 *
 	 *     # Clear cache for a post
 	 *     $ wp embed cache clear 123
+	 *     Success: Cleared oEmbed cache.
 	 */
 	public function clear( $args, $assoc_args ) {
 		/** @var \WP_Embed $wp_embed */
@@ -33,6 +36,12 @@ class Cache_Command extends WP_CLI_Command {
 		$post_id = $args[0];
 
 		$post_metas = get_post_custom_keys( $post_id );
+
+		if ( $post_metas ) {
+			$post_metas = array_filter( $post_metas, function ( $v ) {
+				return '_oembed_' === substr( $v, 0, 8 );
+			} );
+		}
 
 		if ( empty( $post_metas ) ) {
 			WP_CLI::error( 'No cache to clear!' );
@@ -44,10 +53,12 @@ class Cache_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Finds the oEmbed cache post ID for a given URL.
+	 * Finds an oEmbed cache post ID for a given URL.
 	 *
 	 * Starting with WordPress 4.9, embeds that aren't associated with a specific post will be cached in
-	 * a new oembed_cache post type.
+	 * a new oembed_cache post type. There can be more than one such entry for a url depending on attributes and context.
+	 *
+	 * Not to be confused to oEmbed caches for a given post which are stored in the post's metadata.
 	 *
 	 * ## OPTIONS
 	 *
@@ -55,15 +66,19 @@ class Cache_Command extends WP_CLI_Command {
 	 * : URL to retrieve oEmbed data for.
 	 *
 	 * [--width=<width>]
-	 * : Width of the embed in pixels.
+	 * : Width of the embed in pixels. Part of cache key so must match. Defaults to `content_width` if set else 500px, so is theme and context dependent.
 	 *
 	 * [--height=<height>]
-	 * : Height of the embed in pixels.
+	 * : Height of the embed in pixels. Part of cache key so must match. Defaults to 1.5 * default width (`content_width` or 500px), to a maximum of 1000px.
+	 *
+	 * [--discover]
+	 * : Whether to search with the discover attribute set or not. Part of cache key so must match. If not given, will search with attribute: unset, '1', '0', returning first.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Find cache post ID for a given URL.
 	 *     $ wp embed cache find https://www.youtube.com/watch?v=dQw4w9WgXcQ --width=500
+	 *     123
 	 */
 	public function find( $args, $assoc_args ) {
 		if ( Utils\wp_version_compare( '4.9', '<' ) ) {
@@ -75,37 +90,51 @@ class Cache_Command extends WP_CLI_Command {
 
 		$url = $args[0];
 
-		$oembed_args = array(
-			'width'    => (int) Utils\get_flag_value( $assoc_args, 'width' ),
-			'height'   => (int) Utils\get_flag_value( $assoc_args, 'height' ),
-		);
+		// The `$key_suffix` used for caching is part based on serializing the attributes array without normalizing it first so need to try to replicate that.
+		$oembed_args = array();
+		if ( null !== ( $width = Utils\get_flag_value( $assoc_args, 'width' ) ) ) {
+			$oembed_args['width'] = $width; // Keep as string as if from a shortcode attribute.
+		}
+		if ( null !== ( $height = Utils\get_flag_value( $assoc_args, 'height' ) ) ) {
+			$oembed_args['height'] = $height; // Keep as string as if from a shortcode attribute.
+		}
+		$discovers = null !== ( $discover = Utils\get_flag_value( $assoc_args, 'discover' ) ) ? array( $discover ? '1' : '0' ) : array( null, '1', '0' );
 
-		$attr       = wp_parse_args( $oembed_args, wp_embed_defaults( $url ) );
-		$key_suffix = md5( $url . serialize( $attr ) );
+		$attr = wp_parse_args( $oembed_args, wp_embed_defaults( $url ) );
 
-		$cached_post_id = $wp_embed->find_oembed_post_id( $key_suffix );
+		foreach ( $discovers as $discover ) {
+			if ( null !== $discover ) {
+				$attr['discover'] = $discover;
+			}
+			$key_suffix = md5( $url . serialize( $attr ) );
 
-		if ( $cached_post_id ) {
-			WP_CLI::line( $cached_post_id );
+			$cached_post_id = $wp_embed->find_oembed_post_id( $key_suffix );
 
-			return;
+			if ( $cached_post_id ) {
+				WP_CLI::line( $cached_post_id );
+
+				return;
+			}
 		}
 
 		WP_CLI::error( 'No cache post ID found!' );
 	}
 
 	/**
-	 * Triggers a caching of all oEmbed results for a given post.
+	 * Triggers the caching of all oEmbed results for a given post.
+	 *
+	 * oEmbed caches for a post are stored in the post's metadata.
 	 *
 	 * ## OPTIONS
 	 *
 	 * <post_id>
-	 * : ID of the post to do th caching for.
+	 * : ID of the post to do the caching for.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Clear cache for a post
+	 *     # Triggers cache for a post
 	 *     $ wp embed cache trigger 456
+	 *     Success: Caching triggered!
 	 */
 	public function trigger( $args, $assoc_args ) {
 		/** @var \WP_Embed $wp_embed */
@@ -116,14 +145,14 @@ class Cache_Command extends WP_CLI_Command {
 		$post_types = get_post_types( array( 'show_ui' => true ) );
 
 		if ( empty( $post->ID ) ) {
-			WP_CLI::warning( sprintf( 'Post %d does not exist!', $post_id ) );
+			WP_CLI::warning( sprintf( "Post id '%s' not found.", $post_id ) );
 
 			return;
 		}
 
 		/** This filter is documented in wp-includes/class-wp-embed.php */
 		if ( ! in_array( $post->post_type, apply_filters( 'embed_cache_oembed_types', $post_types ), true ) ) {
-			WP_CLI::warning( sprintf( 'Cannot cache oEmbed results for %s post type', $post->post_type ) );
+			WP_CLI::warning( sprintf( "Cannot cache oEmbed results for '%s' post type", $post->post_type ) );
 
 			return;
 		}


### PR DESCRIPTION
See https://github.com/wp-cli/embed-command/issues/18

Review of cache command.

For discussion.

Following based on my no doubt faulty understanding of the core embed code which (shall we say) isn't the easiest to grasp, particularly the caching.

Re: `cache clear`

Adds comment to clarify that `cache clear` only applies to the postmeta caching.

Filters the custom meta to begin with `_oembed_` for better error feedback.

Should there be a facility to clear postmeta caching for all posts, ie just zap all meta beginning `_oembed_`?
Should there be a facility to clear the new WP 4.9 non-post `oembed_cache` stuff?
Should there be a facility to do both?

Re: `cache find`

Adds comment that there can be more than one 'oembed_cache` entry, and that this is different than the postmeta caching.

Expands on some option comments.

Adds new option `discover` and keeps all arguments as strings and set in a particular order, and either uses the new `discover` option or iterates over all likely values of `discover` (none, `'1'`, `'0'`) in trying to find a match. This seems to be needed as the attributes array isn't normalized by core before serializing but I could be wrong.

Re: `cache trigger`

Adds comment to clarify that `cache trigger` only applies to the postmeta caching.

Fixes some docblock comments.

Puts single quotes around variables in error messages and changes the no-post message to be less enthusiastic.

Re testing, adapts and adds some tests.
