### PR TITLE
Handler review suggested changes for discussion.

### DIFF
--- a/features/handler.feature
+++ b/features/handler.feature
@@ -3,12 +3,87 @@ Feature: Manage embed handlers.
   Background:
     Given a WP install
 
-  # See https://core.trac.wordpress.org/changeset/37744
-  @require-wp-4.6
   Scenario: List embed handlers
+    When I run `wp embed handler list`
+    And save STDOUT as {DEFAULT_STDOUT}
+    Then STDOUT should contain:
+      """
+      id
+      """
+    And STDOUT should contain:
+      """
+      regex
+      """
+    And STDOUT should contain:
+      """
+      audio
+      """
+    And STDOUT should contain:
+      """
+      video
+      """
+    And STDOUT should contain:
+      """
+      #http
+      """
+    And STDOUT should not contain:
+      """
+      priority
+      """
+    And STDOUT should not contain:
+      """
+      9999
+      """
+    And STDOUT should not contain:
+      """
+      callback
+      """
+    And STDOUT should not contain:
+      """
+      wp_embed_handler
+      """
+
+    When I run `wp embed handler list --fields=id,regex`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
     When I run `wp embed handler list --fields=priority,id`
-    Then STDOUT should be a table containing rows:
+    Then STDOUT should end with a table containing rows:
       | priority | id                |
-      | 10       | youtube_embed_url |
       | 9999     | audio             |
       | 9999     | video             |
+
+    Given an embed_register_handler.php file:
+      """
+      <?php WP_CLI::add_hook( 'after_wp_load', function() { wp_embed_register_handler( 'my_id', '/regex/', 'callback', 123 ); } );
+      """
+
+    When I run `wp --require=embed_register_handler.php embed handler list`
+    Then STDOUT should be a table containing rows:
+      | id    | regex   |
+      | my_id | /regex/ |
+    And STDOUT should contain:
+      """
+      audio
+      """
+    And STDOUT should contain:
+      """
+      video
+      """
+
+    When I run `wp --require=embed_register_handler.php embed handler list --format=csv --fields=regex,callback,priority`
+    Then STDOUT should contain:
+      """
+      /regex/,callback,123
+      """
+
+    # Handlers are sorted by priority
+    When I run `wp --require=embed_register_handler.php embed handler list --field=id`
+    Then STDOUT should contain:
+      """
+      my_id
+      audio
+      video
+      """

--- a/src/Handler_Command.php
+++ b/src/Handler_Command.php
@@ -10,11 +10,9 @@ use WP_CLI_Command;
  * Retrieves embed handlers.
  */
 class Handler_Command extends WP_CLI_Command {
-	protected $possible_fields = array(
+	protected $default_fields = array(
 		'id',
 		'regex',
-		'callback',
-		'priority',
 	);
 
 	/**
@@ -73,10 +71,10 @@ class Handler_Command extends WP_CLI_Command {
 		foreach ( $wp_embed->handlers as $priority => $handlers ) {
 			foreach ( $handlers as $id => $handler ) {
 				$all_handlers[] = array(
-					'priority' => $priority,
 					'id' => $id,
 					'regex' => $handler['regex'],
 					'callback' => $handler['callback'],
+					'priority' => $priority,
 				);
 			}
 		}
@@ -92,6 +90,6 @@ class Handler_Command extends WP_CLI_Command {
 	 * @return \WP_CLI\Formatter
 	 */
 	protected function get_formatter( &$assoc_args ) {
-		return new Formatter( $assoc_args, $this->possible_fields );
+		return new Formatter( $assoc_args, $this->default_fields );
 	}
 }


### PR DESCRIPTION
See https://github.com/wp-cli/embed-command/issues/18

Review of handler command.

For discussion.

Renames `$possible_fields` array to `$default_fields` to match function and removes non-default entries.

Reorders `priority` handler in `$all_handlers` to match usage (cosmetic).

Adapts and adds some tests.
