### PR TITLE
Provider review suggested changes for discussion.

### DIFF
--- a/features/provider.feature
+++ b/features/provider.feature
@@ -4,8 +4,21 @@ Feature: Manage oEmbed providers.
     Given a WP install
 
   Scenario: List oEmbed providers
-    When I run `wp embed provider list --fields=format,endpoint`
+    When I run `wp embed provider list`
+    And save STDOUT as {DEFAULT_STDOUT}
     Then STDOUT should contain:
+      """
+      format
+      """
+    And STDOUT should contain:
+      """
+      endpoint
+      """
+    And STDOUT should not contain:
+      """
+      regex
+      """
+    And STDOUT should contain:
       """
       youtube\.com/watch.*
       """
@@ -38,10 +51,239 @@ Feature: Manage oEmbed providers.
       spotify.com
       """
 
-  Scenario: Match an oEmbed provider
-    When I run `wp embed provider match https://www.youtube.com/watch?v=dQw4w9WgXcQ`
+    When I run `wp embed provider list --fields=format,endpoint`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    When I run `wp embed provider list --force-regex`
+    Then STDOUT should not contain:
+      """
+      {DEFAULT_STDOUT}
+      """
+    And STDOUT should match /^#http/m
+
+    When I run `wp embed provider list --fields=format`
+    Then STDOUT should contain:
+      """
+      format
+      """
+    And STDOUT should not contain:
+      """
+      endpoint
+      """
     And STDOUT should contain:
+      """
+      youtube\.com/watch.*
+      """
+    And STDOUT should not contain:
+      """
+      youtube.com
+      """
+
+    When I run `wp embed provider list --field=format`
+    Then STDOUT should not contain:
+      """
+      format
+      """
+    And STDOUT should not contain:
+      """
+      endpoint
+      """
+    And STDOUT should contain:
+      """
+      youtube\.com/watch.*
+      """
+    And STDOUT should not contain:
+      """
+      youtube.com
+      """
+
+    When I run `wp embed provider list --field=regex`
+    Then STDOUT should match /^(?:(?:1|0)\n)+$/
+
+  Scenario: Match an oEmbed provider
+    # Provider not requiring discovery
+    When I run `wp embed provider match https://www.youtube.com/watch?v=dQw4w9WgXcQ`
+    Then STDOUT should contain:
       """
       //www.youtube.com/oembed
       """
-    And STDERR should be empty
+
+    # Provider requiring discovery
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed provider match https://asciinema.org/a/140798`
+    And save STDOUT as {DEFAULT_STDOUT}
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
+      """
+      asciinema.org/
+      """
+    And STDOUT should contain:
+      """
+      json
+      """
+    And STDOUT should not contain:
+      """
+      xml
+      """
+
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed provider match https://asciinema.org/a/140798 --link-type=json`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed provider match https://asciinema.org/a/140798 --link-type=xml`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should not contain:
+      """
+      {DEFAULT_STDOUT}
+      """
+    And STDOUT should contain:
+      """
+      asciinema.org/
+      """
+    And STDOUT should contain:
+      """
+      xml
+      """
+    And STDOUT should not contain:
+      """
+      json
+      """
+
+  # Depends on `oembed_remote_get_args` filter introduced WP 4.0 https://core.trac.wordpress.org/ticket/23442
+  @require-wp-4.0
+  Scenario: Discover a provider with limited response size
+    When I run `wp embed provider match https://asciinema.org/a/140798`
+    And save STDOUT as {DEFAULT_STDOUT}
+
+    # Response limit too small
+    When I try `wp embed provider match https://asciinema.org/a/140798 --limit-response-size=10`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: No oEmbed provider found for given URL.
+      """
+
+    # Response limit big enough
+    When I run `wp embed provider match https://asciinema.org/a/140798 --limit-response-size=50000`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+  Scenario: Fail to match an oEmbed provider
+    When I try `wp embed provider match https://www.example.com/watch?v=dQw4w9WgXcQ --no-discover`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: No oEmbed provider found for given URL. Maybe try discovery?
+      """
+    And STDOUT should be empty
+
+    When I try `wp embed provider match https://www.example.com/watch?v=dQw4w9WgXcQ`
+    Then the return code should be 1
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "contain" to ignore these.
+    And STDERR should contain:
+      """
+      Error: No oEmbed provider found for given URL.
+      """
+    And STDOUT should be empty
+
+    When I try `wp embed provider match https://www.example.com/watch?v=dQw4w9WgXcQ --discover`
+    Then the return code should be 1
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "contain" to ignore these.
+    And STDERR should contain:
+      """
+      Error: No oEmbed provider found for given URL.
+      """
+    And STDOUT should be empty
+
+  Scenario: Only match an oEmbed provider if discover
+    When I try `wp embed provider match https://asciinema.org/a/140798 --no-discover`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: No oEmbed provider found for given URL. Maybe try discovery?
+      """
+    And STDOUT should be empty
+
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed provider match https://asciinema.org/a/140798`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
+      """
+      asciinema.org/
+      """
+    And STDOUT should contain:
+      """
+      140798
+      """
+
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed provider match https://asciinema.org/a/140798 --discover`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
+      """
+      asciinema.org/
+      """
+
+  Scenario: Incompatible or wrong options
+    When I try `wp embed provider match https://www.example.com/watch?v=dQw4w9WgXcQ --no-discover --limit-response-size=50000`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'limit-response-size' option can only be used with discovery.
+      """
+    And STDOUT should be empty
+
+    When I try `wp embed provider match https://www.example.com/watch?v=dQw4w9WgXcQ --no-discover --link-type=json`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'link-type' option can only be used with discovery.
+      """
+    And STDOUT should be empty
+
+    When I try `wp embed provider match https://www.example.com/watch?v=dQw4w9WgXcQ --no-discover --limit-response-size=50000 --link-type=json`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'limit-response-size' and 'link-type' options can only be used with discovery.
+      """
+    And STDOUT should be empty
+
+    When I try `wp embed provider match https://www.example.com/watch?v=dQw4w9WgXcQ --no-discover --link-type=blah`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: Parameter errors:
+       Invalid value specified for 'link-type'
+      """
+    And STDOUT should be empty

--- a/features/provider.feature
+++ b/features/provider.feature
@@ -169,7 +169,7 @@ Feature: Manage oEmbed providers.
       json
       """
 
-  # Depends on `oembed_remote_get_args` filter introduced WP 4.0 https://core.trac.wordpress.org/ticket/23442
+  # Depends on `oembed_remote_get_args` filter introduced in WP 4.0 https://core.trac.wordpress.org/ticket/23442
   @require-wp-4.0
   Scenario: Discover a provider with limited response size
     When I run `wp embed provider match https://asciinema.org/a/140798`

--- a/src/Provider_Command.php
+++ b/src/Provider_Command.php
@@ -38,7 +38,7 @@ class Provider_Command extends WP_CLI_Command {
 	 * ---
 	 *
 	 * [--force-regex]
-	 * : Turn the asterisk-type provider URLs into regexs.
+	 * : Turn the asterisk-type provider URLs into regexes.
 	 *
 	 * ## AVAILABLE FIELDS
 	 *


### PR DESCRIPTION
See https://github.com/wp-cli/embed-command/issues/18

Review of provider command.

For discussion.

Re: `provider list`

Renames `$possible_fields` array to `$default_fields` to match function.

Tweeks `force-regex` option comment.

Replaces copy-pasta optional fields in docblock with `regex`, and adds it to `$providers` array.

Re: `provider match`

Removes unimplemented `verbose` option.

Adds extra comment and error-checking that the `limit-response-size` option can only be used when discovering, and warns that it doesn't work for WP < 4.0.

Renames `format` option to `link-type` as `format` associated with standard WP-CLI table/csv/json/etc formats, and removes default so it will accept all by default, and adds extra comment and error-checking that it can only be used when discovering.

Fixes examples docblock.

Flips `No oEmbed provider found` error message the right way round.

Re testing, adapts and adds some tests.
