### PR TITLE
Fetch review suggested changes for discussion.

### DIFF
--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -4,6 +4,7 @@ Feature: Manage oEmbed cache.
     Given a WP install
 
   Scenario: Get HTML embed code for a given URL
+    # Provider not requiring discovery
     When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --width=500`
     Then STDOUT should contain:
       """
@@ -14,16 +15,37 @@ Feature: Manage oEmbed cache.
       dQw4w9WgXcQ
       """
 
+    # Provider requiring discovery
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed fetch https://asciinema.org/a/140798`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
+      """
+      asciinema.org/
+      """
+
   Scenario: Get raw oEmbed data for a given URL
     When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --raw`
+    And save STDOUT as {DEFAULT_STDOUT}
     Then STDOUT should contain:
       """
       "type":"video"
       """
 
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --raw --raw-format=json`
+    And save STDOUT as {DEFAULT_STDOUT}
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
   Scenario: Bails when no oEmbed provider is found for a raw request
     When I try `wp embed fetch https://foo.example.com --raw`
-    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices so use "contain" to ignore these.
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discovery so use "contain" to ignore these.
     Then STDERR should contain:
       """
       Error: No oEmbed provider found for given URL.
@@ -37,13 +59,19 @@ Feature: Manage oEmbed cache.
       """
 
   Scenario: Makes unknown URLs clickable
-    When I run `wp embed fetch https://foo.example.com`
-    Then STDOUT should contain:
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed fetch https://foo.example.com`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
       """
       <a href="https://foo.example.com">https://foo.example.com</a>
       """
 
-  Scenario: Caches oEmbdd response data for a given post
+  Scenario: Caches oEmbed response data for a given post
     When I run `wp post create --post_title="Foo Bar" --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {POST_ID}
@@ -61,8 +89,114 @@ Feature: Manage oEmbed cache.
       """
 
   Scenario: Return data as XML when requested
-    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --format=xml --raw`
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --raw-format=xml --raw`
     Then STDOUT should contain:
       """
       <type>video</type>
       """
+
+  # Depends on `oembed_remote_get_args` filter introduced WP 4.0 https://core.trac.wordpress.org/ticket/23442
+  @require-wp-4.0
+  Scenario: Get embed code for a URL with limited response size
+    # Need post_id for caching to work for WP < 4.9
+    When I run `wp post create --post_title="Foo Bar" --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --post-id={POST_ID}`
+    And save STDOUT as {DEFAULT_STDOUT}
+    Then STDOUT should contain:
+      """
+      iframe
+      """
+
+    # Response limit too small but cached so ignored.
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --post-id={POST_ID} --limit-response-size=10`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    # Response limit too small and skip cache (and as html failed the cache will not be updated)
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --post-id={POST_ID} --limit-response-size=10 --skip-cache`
+    Then STDOUT should not contain:
+      """
+      {DEFAULT_STDOUT}
+      """
+    And STDOUT should be:
+      """
+      <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">https://www.youtube.com/watch?v=dQw4w9WgXcQ</a>
+      """
+
+    # Response limit big enough and don't skip cache but as previous failed result not cached it doesn't matter
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --post-id={POST_ID} --limit-response-size=50000`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    # Response limit big enough and skip cache
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --post-id={POST_ID} --limit-response-size=50000 --skip-cache`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+  # Same as above but without the post_id. WP > 4.9 only
+  @require-wp-4.9
+  Scenario: Get embed code for a URL with limited response size and post-less cache
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ`
+    And save STDOUT as {DEFAULT_STDOUT}
+    Then STDOUT should contain:
+      """
+      iframe
+      """
+
+    # Response limit too small but cached so ignored.
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --limit-response-size=10`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    # Response limit too small and skip cache (and as html failed the cache will not be updated)
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --limit-response-size=10 --skip-cache`
+    Then STDOUT should not contain:
+      """
+      {DEFAULT_STDOUT}
+      """
+    And STDOUT should be:
+      """
+      <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">https://www.youtube.com/watch?v=dQw4w9WgXcQ</a>
+      """
+
+    # Response limit big enough and don't skip cache but as previous failed result not cached it doesn't matter
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --limit-response-size=50000`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    # Response limit big enough and skip cache
+    When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --limit-response-size=50000 --skip-cache`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+  Scenario: Incompatible options
+    When I try `wp embed fetch https://www.example.com/watch?v=dQw4w9WgXcQ --no-discover --limit-response-size=50000`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'limit-response-size' option can only be used with discovery.
+      """
+    And STDOUT should be empty
+
+    When I try `wp embed fetch https://www.example.com/watch?v=dQw4w9WgXcQ --raw-format=json`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'raw-format' option can only be used with the 'raw' option.
+      """
+    And STDOUT should be empty

--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -142,7 +142,7 @@ Feature: Manage oEmbed cache.
       {DEFAULT_STDOUT}
       """
 
-  # Same as above but without the post_id. WP > 4.9 only
+  # Same as above but without the post_id. WP >= 4.9 only
   @require-wp-4.9
   Scenario: Get embed code for a URL with limited response size and post-less cache
     When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ`
@@ -182,6 +182,21 @@ Feature: Manage oEmbed cache.
     Then STDOUT should be:
       """
       {DEFAULT_STDOUT}
+      """
+
+  # Depends on `wp_filter_pre_oembed_result` filter introduced WP 4.5.3 https://core.trac.wordpress.org/ticket/36767
+  @require-wp-4.5.3
+  Scenario: Fetch locally provided URL
+    When I run `wp embed fetch http://example.com/?p=1`
+    Then STDOUT should contain:
+      """
+      Hello world!
+      """
+
+    When I run `wp embed fetch http://example.com/?p=1 --raw`
+    Then STDOUT should contain:
+      """
+      Hello world!
       """
 
   Scenario: Incompatible options


### PR DESCRIPTION
See https://github.com/wp-cli/embed-command/issues/18

Review of fetch command.

For discussion.

This command seemed to have quite a bit of residue code in it. Also I found trying to work out what core is/was doing very difficult so there's probably mistaken suggestions here.

Differentiates between non-raw and raw behaviour in the description docblock.

Moves the `raw` option closer to the renamed `raw-format` option.

Adds extra comment to `skip-cache` option that it doesn't apply in raw mode.

Adds comment and error-checking that the `limit-response-size` option can only be used when discovering, and warns that it doesn't work for WP < 4.0.

Renames `format` option to `raw-format` to emphasise that it only applies in raw mode, and adds extra comment and error-checking that it can only be used in raw mode.

As with the cache command, keeps all arguments as strings and set in a particular order, as this seems to be needed since the attributes array isn't normalized by core before serializing.

Removes setting the `oembed_linktypes` and `oembed_remote_get_args` filters if `$format` (now `$raw_format`) set as they don't seem to be needed.

Re `raw` mode

Removes overriding the `pre_oembed_result` filter (and removes its `filter_pre_oembed_result()` method) as that isn't applied here as far as I can see.

Removes inner-check if `$raw`. Splits out the check for `SimpleXMLElement` and returns error if not available if xml requested.

Removes some residue code after `raw` returns.

Re non-`raw` mode

Gives warning if `post_id` specified and not found.

Adds `oembed_ttl` filter to make sure cache is skipped and adds `embed_oembed_discover` filter to make sure discovery is disabled.

For WP < 4.9, if no post id given then adds `embed_maybe_make_link` filter so that can check for providers after `WP_Embed::shortcode()` returns false, and does so by calling `wp_oembed_get()`. If that too returns nothing, then calls `WP_Embed::maybe_make_link()` to return link html for WP 4.9 compat.

Re testing, adapts and adds some tests. Could do with some more.
