### PR TITLE
Don't always return clickable link; add 2 new options; misc other fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ matrix:
     - php: 5.3
       dist: precise
       env: WP_VERSION=latest
+    - php: 7.0
+      env: WP_VERSION=4.5.3
+    - php: 7.0
+      env: WP_VERSION=4.3.1
 
 before_install:
   - |

--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -52,9 +52,9 @@ Feature: Manage oEmbed cache.
       <iframe
      """
 
-    # Unknown provider requiring discovery but not returning iframe so would be sanitized for WP >= 4.4 without 'skip-sanitation' option.
+    # Unknown provider requiring discovery but not returning iframe so would be sanitized for WP >= 4.4 without 'skip-sanitization' option.
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed fetch https://asciinema.org/a/140798 --skip-sanitation`
+    When I try `wp embed fetch https://asciinema.org/a/140798 --skip-sanitization`
     Then the return code should be 0
     And STDERR should not contain:
       """
@@ -97,7 +97,7 @@ Feature: Manage oEmbed cache.
       """
     And STDOUT should be empty
 
-  # No sanitation prior to WP 4.4.
+  # No sanitization prior to WP 4.4.
   @less-than-wp-4.4
   Scenario: Get HTML embed code for a given URL that requires discovery and is sanitized
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.

--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -186,13 +186,13 @@ Feature: Manage oEmbed cache.
 
   # WP prior to 4.9 does not return clickable link.
   @less-than-wp-4.9
-  Scenario: Makes unknown URLs clickable
+  Scenario: Doesn't make unknown URLs clickable
     When I try `wp embed fetch https://foo.example.com`
     Then the return code should be 1
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "contain" to cater for these.
-    And STDERR should not contain:
+    And STDERR should contain:
       """
-      Error: No oEmbed provider found for given URL. Maybe try discovery?
+      Error: There was an error fetching the oEmbed data.
       """
     And STDOUT should be empty
 

--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -3,8 +3,9 @@ Feature: Manage oEmbed cache.
   Background:
     Given a WP install
 
+  # Behavior that's the same for all WP versions.
   Scenario: Get HTML embed code for a given URL
-    # Provider not requiring discovery
+    # Known provider not requiring discovery.
     When I run `wp embed fetch https://www.youtube.com/watch?v=dQw4w9WgXcQ --width=500`
     Then STDOUT should contain:
       """
@@ -15,7 +16,90 @@ Feature: Manage oEmbed cache.
       dQw4w9WgXcQ
       """
 
-    # Provider requiring discovery
+    # Unknown provider (taken from https://oembed.com) requiring discovery but returning iframe so not sanitized.
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed fetch http://LearningApps.org/259`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
+      """
+      LearningApps.org/
+     """
+    And STDOUT should contain:
+      """
+      <iframe
+     """
+
+    # How unknown provider checked depends on WP version and post_id so recheck with post_id.
+    When I run `wp post create --post_title="Foo Bar" --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+    When I try `wp embed fetch http://LearningApps.org/259 --post-id={POST_ID}`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
+      """
+      LearningApps.org/
+     """
+    And STDOUT should contain:
+      """
+      <iframe
+     """
+
+    # Unknown provider requiring discovery but not returning iframe so would be sanitized for WP >= 4.4 without 'skip-sanitation' option.
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed fetch https://asciinema.org/a/140798 --skip-sanitation`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
+      """
+      asciinema.org/
+      """
+    And STDOUT should contain:
+      """
+      <a
+      """
+    And STDOUT should not contain:
+      """
+      <iframe
+     """
+
+  # WP 4.9 always returns clickable link even for sanitized oEmbed responses.
+  @require-wp-4.9
+  Scenario: Get HTML embed code for a given URL that requires discovery and is sanitized
+    When I run `wp embed fetch https://asciinema.org/a/140798`
+    Then STDOUT should contain:
+      """
+      asciinema.org/
+      """
+    And STDOUT should contain:
+      """
+      <a
+      """
+
+  # `wp_filter_oembed_result` filter introduced WP 4.4 which sanitizes oEmbed responses that don't include an iframe.
+  @less-than-wp-4.9 @require-wp-4.4
+  Scenario: Get HTML embed code for a given URL that requires discovery and is sanitized
+    When I try `wp embed fetch https://asciinema.org/a/140798`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: There was an error fetching the oEmbed data.
+      """
+    And STDOUT should be empty
+
+  # No sanitation prior to WP 4.4.
+  @less-than-wp-4.4
+  Scenario: Get HTML embed code for a given URL that requires discovery and is sanitized
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
     When I try `wp embed fetch https://asciinema.org/a/140798`
     Then the return code should be 0
@@ -43,6 +127,39 @@ Feature: Manage oEmbed cache.
       {DEFAULT_STDOUT}
       """
 
+    # Raw requests are not sanitized.
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed fetch https://asciinema.org/a/140798 --raw`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
+      """
+      asciinema.org
+      """
+
+  Scenario: Fail then succeed when given unknown discoverable provider for a raw request, depending on discover option
+    When I try `wp embed fetch http://LearningApps.org/259 --raw --no-discover`
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discovery so use "contain" to ignore these.
+    Then STDERR should contain:
+      """
+      Error: No oEmbed provider found for given URL. Maybe try discovery?
+      """
+
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed fetch http://LearningApps.org/259 --raw`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      Error:
+      """
+    And STDOUT should contain:
+      """
+      LearningApps.org
+     """
+
   Scenario: Bails when no oEmbed provider is found for a raw request
     When I try `wp embed fetch https://foo.example.com --raw`
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discovery so use "contain" to ignore these.
@@ -51,33 +168,48 @@ Feature: Manage oEmbed cache.
       Error: No oEmbed provider found for given URL.
       """
 
-  Scenario: Bails when no oEmbed provider is found for a raw request is found and discovery is off
+  Scenario: Bails when no oEmbed provider is found for a raw request and discovery is off
     When I try `wp embed fetch https://foo.example.com --raw --discover=0`
     Then STDERR should be:
       """
       Error: No oEmbed provider found for given URL. Maybe try discovery?
       """
 
+  # WP 4.9 always returns clickable link.
+  @require-wp-4.9
   Scenario: Makes unknown URLs clickable
-    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I run `wp embed fetch https://foo.example.com`
+    Then STDOUT should contain:
+      """
+      <a href="https://foo.example.com">https://foo.example.com</a>
+      """
+
+  # WP prior to 4.9 does not return clickable link.
+  @less-than-wp-4.9
+  Scenario: Makes unknown URLs clickable
     When I try `wp embed fetch https://foo.example.com`
+    Then the return code should be 1
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "contain" to cater for these.
+    And STDERR should not contain:
+      """
+      Error: No oEmbed provider found for given URL. Maybe try discovery?
+      """
+    And STDOUT should be empty
+
+  Scenario: Caches oEmbed response data for a given post
+    # Note need post author for 'unfiltered_html' check to work for WP < 4.4.
+    When I run `wp post create --post_title="Foo Bar" --post_author=1 --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
+    When I try `wp embed fetch https://foo.example.com --post-id={POST_ID}`
     Then the return code should be 0
     And STDERR should not contain:
       """
       Error:
       """
     And STDOUT should contain:
-      """
-      <a href="https://foo.example.com">https://foo.example.com</a>
-      """
-
-  Scenario: Caches oEmbed response data for a given post
-    When I run `wp post create --post_title="Foo Bar" --porcelain`
-    Then STDOUT should be a number
-    And save STDOUT as {POST_ID}
-
-    When I run `wp embed fetch https://foo.example.com --post-id={POST_ID}`
-    Then STDOUT should contain:
       """
       <a href="https://foo.example.com">https://foo.example.com</a>
       """
@@ -98,8 +230,8 @@ Feature: Manage oEmbed cache.
   # Depends on `oembed_remote_get_args` filter introduced WP 4.0 https://core.trac.wordpress.org/ticket/23442
   @require-wp-4.0
   Scenario: Get embed code for a URL with limited response size
-    # Need post_id for caching to work for WP < 4.9
-    When I run `wp post create --post_title="Foo Bar" --porcelain`
+    # Need post_id for caching to work for WP < 4.9, and also post_author for caching to work for WP < 4.4 (due to 'unfiltered_html' check).
+    When I run `wp post create --post_title="Foo Bar" --post_author=1 --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {POST_ID}
 
@@ -107,7 +239,7 @@ Feature: Manage oEmbed cache.
     And save STDOUT as {DEFAULT_STDOUT}
     Then STDOUT should contain:
       """
-      iframe
+      <iframe
       """
 
     # Response limit too small but cached so ignored.
@@ -149,7 +281,7 @@ Feature: Manage oEmbed cache.
     And save STDOUT as {DEFAULT_STDOUT}
     Then STDOUT should contain:
       """
-      iframe
+      <iframe
       """
 
     # Response limit too small but cached so ignored.
@@ -197,6 +329,90 @@ Feature: Manage oEmbed cache.
     Then STDOUT should contain:
       """
       Hello world!
+      """
+
+  # `wp_embed_handler_youtube` handler introduced WP 4.0.
+  @require-wp-4.0
+  Scenario: Invoke built-in YouTube handler
+    When I run `wp post create --post_title="Foo Bar" --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp embed fetch http://www.youtube.com/embed/dQw4w9WgXcQ --post-id={POST_ID}`
+    Then STDOUT should contain:
+      """
+      youtube
+      """
+    And STDOUT should contain:
+      """
+      <iframe
+      """
+
+  Scenario: Invoke built-in audio handler
+    When I run `wp post create --post_title="Foo Bar" --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp embed fetch http://www.example.com/never-gonna-give-you-up.mp3 --post-id={POST_ID}`
+    Then STDOUT should contain:
+      """
+      example.com
+      """
+    And STDOUT should contain:
+      """
+      [audio
+      """
+
+    When I run `wp embed fetch http://www.example.com/never-gonna-give-you-up.mp3 --post-id={POST_ID} --do-shortcode`
+    Then STDOUT should contain:
+      """
+      example.com
+      """
+    And STDOUT should contain:
+      """
+      <audio
+      """
+
+  Scenario: Invoke built-in video handler
+    When I run `wp post create --post_title="Foo Bar" --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp embed fetch http://www.example.com/never-gonna-give-you-up.mp4 --post-id={POST_ID}`
+    Then STDOUT should contain:
+      """
+      example.com
+      """
+    And STDOUT should contain:
+      """
+      [video
+      """
+
+    When I run `wp embed fetch http://www.example.com/never-gonna-give-you-up.mp4 --post-id={POST_ID} --do-shortcode`
+    Then STDOUT should contain:
+      """
+      example.com
+      """
+    And STDOUT should contain:
+      """
+      <video
+      """
+
+  # `wp_embed_handler_googlevideo` handler deprecated WP 4.6.
+  @less-than-wp-4.6
+  Scenario: Invoke built-in Google Video handler
+    When I run `wp post create --post_title="Foo Bar" --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp embed fetch http://video.google.com/videoplay?docid=123456789 --post-id={POST_ID}`
+    Then STDOUT should contain:
+      """
+      video.google.com
+      """
+    And STDOUT should contain:
+      """
+      <embed
       """
 
   Scenario: Incompatible options

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -107,7 +107,7 @@ class Fetch_Command extends WP_CLI_Command {
 				$args['limit_response_size'] = $response_size_limit;
 
 				return $args;
-			} );
+			}, PHP_INT_MAX );
 		}
 
 		// If raw, query providers directly, by-passing cache.
@@ -119,7 +119,7 @@ class Fetch_Command extends WP_CLI_Command {
 			// Make 'oembed_dataparse' filter a no-op so get raw unsanitized data.
 			add_filter( 'oembed_dataparse', function ( $return, $data, $url ) {
 				return $data;
-			}, 9999, 3 ); // Large priority to by-pass other 'oembed_dataparse' filters.
+			}, PHP_INT_MAX, 3 );
 
 			// Allow `wp_filter_pre_oembed_result()` to provide local URLs (WP >= 4.5.3).
 			$data = apply_filters( 'pre_oembed_result', null, $url, $oembed_args );
@@ -168,19 +168,19 @@ class Fetch_Command extends WP_CLI_Command {
 		if ( Utils\get_flag_value( $assoc_args, 'skip-cache' ) ) {
 			$wp_embed->usecache = false;
 			// In order to skip caching, also need `$cached_recently` to be false in `WP_Embed::shortcode()`, so set TTL to zero.
-			add_filter( 'oembed_ttl', '__return_zero' );
+			add_filter( 'oembed_ttl', '__return_zero', PHP_INT_MAX );
 		} else {
 			$wp_embed->usecache = true;
 		}
 
 		// `WP_Embed::shortcode()` sets the 'discover' attribute based on 'embed_oembed_discover' filter, no matter what's passed to it.
-		add_filter( 'embed_oembed_discover', $discover ? '__return_true' : '__return_false' );
+		add_filter( 'embed_oembed_discover', $discover ? '__return_true' : '__return_false', PHP_INT_MAX );
 
 		// For WP < 4.9, `WP_Embed::shortcode()` won't check providers if no post_id supplied, so set `maybe_make_link()` to return false so can check and do it ourselves.
 		// Also set if WP < 4.4 and don't have 'unfiltered_html' privileges on post.
 		$check_providers = Utils\wp_version_compare( '4.9', '<' ) && ( ! $post_id || ( Utils\wp_version_compare( '4.4', '<' ) && ! author_can( $post_id, 'unfiltered_html' ) ) );
 		if ( $check_providers ) {
-			add_filter( 'embed_maybe_make_link', '__return_false' );
+			add_filter( 'embed_maybe_make_link', '__return_false', PHP_INT_MAX );
 		}
 
 		$html = $wp_embed->shortcode( $oembed_args, $url );

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -117,6 +117,7 @@ class Fetch_Command extends WP_CLI_Command {
 			$oembed_args['discover'] = $discover;
 
 			// Make 'oembed_dataparse' filter a no-op so get raw unsanitized data.
+			remove_all_filters( 'oembed_dataparse' ); // Save a few cycles.
 			add_filter( 'oembed_dataparse', function ( $return, $data, $url ) {
 				return $data;
 			}, PHP_INT_MAX, 3 );

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -35,8 +35,8 @@ class Fetch_Command extends WP_CLI_Command {
 	 * [--skip-cache]
 	 * : Ignore already cached oEmbed responses. Has no effect if using the 'raw' option, which doesn't use the cache.
 	 *
-	 * [--skip-sanitation]
-	 * : Remove the filter that WordPress from 4.4 onwards uses to sanitize oEmbed responses. Has no effect if using the 'raw' option, which by-passes sanitation.
+	 * [--skip-sanitization]
+	 * : Remove the filter that WordPress from 4.4 onwards uses to sanitize oEmbed responses. Has no effect if using the 'raw' option, which by-passes sanitization.
 	 *
 	 * [--do-shortcode]
 	 * : If the URL is handled by a registered embed handler and returns a shortcode, do shortcode and return result. Has no effect if using the 'raw' option, which by-passes handlers.
@@ -161,7 +161,7 @@ class Fetch_Command extends WP_CLI_Command {
 			}
 		}
 
-		if ( Utils\get_flag_value( $assoc_args, 'skip-sanitation' ) ) {
+		if ( Utils\get_flag_value( $assoc_args, 'skip-sanitization' ) ) {
 			remove_filter( 'oembed_dataparse', 'wp_filter_oembed_result', 10, 3 );
 		}
 


### PR DESCRIPTION
Moves the `skip-cache` option to before the new `skip-sanitation` option.

Adds 2 new non-raw options `skip-sanitation` and `do-shortcode`, the first if set removes the `wp_filter_oembed_result()` filter (added WP 4.4) and the second if set executes the shortcode returned by the `'audio'` and `'video'` embed handlers and returns the results.

Makes sure `$oembed_args['discover']` is set when not calling `WP_Embed::shortcode()` as it's not ignored by other functions/methods (though usually defaults to true I think).

In non-raw mode only:

Always sets the `'embed_oembed_discover'` filter depending on `$discover` as the default was false for WP < 4.4.

Checks providers not only when WP < 4.9 and no `post_id` but also when WP < 4.4 and no `'unfiltered_html'` privileges on the post as that was also part of the discovery check.

Removes always returning a clickable link (added for WP 4.9 compat in https://github.com/wp-cli/embed-command/pull/29) and just fails instead (see https://github.com/wp-cli/embed-command/pull/29#issuecomment-355042624).

Other:

Corrects some comments.

Adjusts and adds tests. In particular uses the fab new `@less-than-wp` tag (which actually works, thanks to @schlessera).

Also adds testing WP 4.5.3 and WP 4.3.1 to the Travis matrix so all tests get run. (Although `.travis.yml` will be overwritten if the scaffolded tests get updated I've a cunning plan to deal with this.)

Re the 2 new options, these may go against the "Decisions, not options" philosophy so could be left out.

Anyway the fixes here aren't that major so as soon as this is merged we should begin integrating the command I think.