### PR TITLE
Remove requires WP >= 2.9 from command.php; tidy up composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,28 +3,36 @@
     "description": "Inspects oEmbed providers, clears embed cache, and more.",
     "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/embed-command",
+    "support": {
+        "issues": "https://github.com/wp-cli/embed-command/issues"
+    },
     "license": "MIT",
-    "authors": [],
+    "authors": [
+        {
+            "name": "Pascal Birchler",
+            "homepage": "https://pascalbirchler.com/"
+        }
+    ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
-        "files": [
-            "embed-command.php"
-        ],
         "psr-4": {
             "WP_CLI\\Embeds\\": "src/"
-        }
+        },
+        "files": [
+            "embed-command.php"
+        ]
     },
-    "require": {
-        "wp-cli/wp-cli": "^1.1.0"
-    },
+    "require": {},
     "require-dev": {
-        "behat/behat": "~2.5"
+        "behat/behat": "~2.5",
+        "wp-cli/wp-cli": "^1.5"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev"
         },
+        "bundled": true,
         "commands": [
             "embed",
             "embed fetch",
@@ -34,7 +42,6 @@
             "embed cache clear",
             "embed cache find",
             "embed cache trigger"
-        ],
-        "bundled": true
+        ]
     }
 }

--- a/embed-command.php
+++ b/embed-command.php
@@ -14,34 +14,10 @@ if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {
 	WP_CLI::add_command( 'embed', '\WP_CLI\Embeds\Embeds_Namespace' );
 }
 
-WP_CLI::add_command( 'embed fetch', '\WP_CLI\Embeds\Fetch_Command', array(
-	'before_invoke' => function () {
-		if ( \WP_CLI\Utils\wp_version_compare( '2.9', '<' ) ) {
-			WP_CLI::error( 'Requires WordPress 2.9 or greater.' );
-		}
-	},
-) );
+WP_CLI::add_command( 'embed fetch', '\WP_CLI\Embeds\Fetch_Command' );
 
-WP_CLI::add_command( 'embed provider', '\WP_CLI\Embeds\Provider_Command', array(
-	'before_invoke' => function () {
-		if ( \WP_CLI\Utils\wp_version_compare( '2.9', '<' ) ) {
-			WP_CLI::error( 'Requires WordPress 2.9 or greater.' );
-		}
-	},
-) );
+WP_CLI::add_command( 'embed provider', '\WP_CLI\Embeds\Provider_Command' );
 
-WP_CLI::add_command( 'embed handler', '\WP_CLI\Embeds\Handler_Command', array(
-	'before_invoke' => function () {
-		if ( \WP_CLI\Utils\wp_version_compare( '2.9', '<' ) ) {
-			WP_CLI::error( 'Requires WordPress 2.9 or greater.' );
-		}
-	},
-) );
+WP_CLI::add_command( 'embed handler', '\WP_CLI\Embeds\Handler_Command' );
 
-WP_CLI::add_command( 'embed cache', '\WP_CLI\Embeds\Cache_Command', array(
-	'before_invoke' => function () {
-		if ( \WP_CLI\Utils\wp_version_compare( '2.9', '<' ) ) {
-			WP_CLI::error( 'Requires WordPress 2.9 or greater.' );
-		}
-	},
-) );
+WP_CLI::add_command( 'embed cache', '\WP_CLI\Embeds\Cache_Command' );


### PR DESCRIPTION
Closes #18 

Removes WP >= 2.9 check from `embed-command.php`.

Tidies up `composer.json` to make same as other bundled commands.