### PR TITLE
Apply PHPCS `WP_CLI_CS` rules

### DIFF
--- a/embed-command.php
+++ b/embed-command.php
@@ -4,10 +4,10 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$wpcli_embed_autoload = __DIR__ . '/vendor/autoload.php';
+$wpcli_embed_autoloader = __DIR__ . '/vendor/autoload.php';
 
-if ( file_exists( $wpcli_embed_autoload ) ) {
-	require_once $wpcli_embed_autoload;
+if ( file_exists( $wpcli_embed_autoloader ) ) {
+	require_once $wpcli_embed_autoloader;
 }
 
 if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {

--- a/embed-command.php
+++ b/embed-command.php
@@ -4,10 +4,10 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$autoload = __DIR__ . '/vendor/autoload.php';
+$wpcli_embed_autoload = __DIR__ . '/vendor/autoload.php';
 
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+if ( file_exists( $wpcli_embed_autoload ) ) {
+	require_once $wpcli_embed_autoload;
 }
 
 if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -105,7 +105,11 @@ class Cache_Command extends WP_CLI_Command {
 		if ( null !== $height ) {
 			$oembed_args['height'] = $height; // Keep as string as if from a shortcode attribute.
 		}
-		$discovers = ( null !== $discover ) ? array( $discover ? '1' : '0' ) : array( null, '1', '0' );
+		if ( null !== $discover ) {
+			$discovers = array( ( $discover ) ? '1' : '0' );
+		} else {
+			$discovers = array( null, '1', '0' );
+		}
 
 		$attr = wp_parse_args( $oembed_args, wp_embed_defaults( $url ) );
 

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -117,6 +117,7 @@ class Cache_Command extends WP_CLI_Command {
 			if ( null !== $discover ) {
 				$attr['discover'] = $discover;
 			}
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- needed to mimic WP Core behavior. See: \WP_Embed::shortcode.
 			$key_suffix = md5( $url . serialize( $attr ) );
 
 			$cached_post_id = $wp_embed->find_oembed_post_id( $key_suffix );

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -91,17 +91,21 @@ class Cache_Command extends WP_CLI_Command {
 		/** @var \WP_Embed $wp_embed */
 		global $wp_embed;
 
-		$url = $args[0];
+		$url      = $args[0];
+		$width    = Utils\get_flag_value( $assoc_args, 'width' );
+		$height   = Utils\get_flag_value( $assoc_args, 'height' );
+		$discover = Utils\get_flag_value( $assoc_args, 'discover' );
 
 		// The `$key_suffix` used for caching is part based on serializing the attributes array without normalizing it first so need to try to replicate that.
 		$oembed_args = array();
-		if ( null !== ( $width = Utils\get_flag_value( $assoc_args, 'width' ) ) ) {
+
+		if ( null !== $width ) {
 			$oembed_args['width'] = $width; // Keep as string as if from a shortcode attribute.
 		}
-		if ( null !== ( $height = Utils\get_flag_value( $assoc_args, 'height' ) ) ) {
+		if ( null !== $height ) {
 			$oembed_args['height'] = $height; // Keep as string as if from a shortcode attribute.
 		}
-		$discovers = null !== ( $discover = Utils\get_flag_value( $assoc_args, 'discover' ) ) ? array( $discover ? '1' : '0' ) : array( null, '1', '0' );
+		$discovers = null !== $discover ? array( $discover ? '1' : '0' ) : array( null, '1', '0' );
 
 		$attr = wp_parse_args( $oembed_args, wp_embed_defaults( $url ) );
 

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -105,7 +105,7 @@ class Cache_Command extends WP_CLI_Command {
 		if ( null !== $height ) {
 			$oembed_args['height'] = $height; // Keep as string as if from a shortcode attribute.
 		}
-		$discovers = null !== $discover ? array( $discover ? '1' : '0' ) : array( null, '1', '0' );
+		$discovers = ( null !== $discover ) ? array( $discover ? '1' : '0' ) : array( null, '1', '0' );
 
 		$attr = wp_parse_args( $oembed_args, wp_embed_defaults( $url ) );
 

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -158,7 +158,7 @@ class Cache_Command extends WP_CLI_Command {
 		}
 
 		/** This filter is documented in wp-includes/class-wp-embed.php */
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WP Core hook.
 		if ( ! in_array( $post->post_type, apply_filters( 'embed_cache_oembed_types', $post_types ), true ) ) {
 			WP_CLI::warning( sprintf( "Cannot cache oEmbed results for '%s' post type", $post->post_type ) );
 

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -38,9 +38,12 @@ class Cache_Command extends WP_CLI_Command {
 		$post_metas = get_post_custom_keys( $post_id );
 
 		if ( $post_metas ) {
-			$post_metas = array_filter( $post_metas, function ( $v ) {
-				return '_oembed_' === substr( $v, 0, 8 );
-			} );
+			$post_metas = array_filter(
+				$post_metas,
+				function ( $v ) {
+					return '_oembed_' === substr( $v, 0, 8 );
+				}
+			);
 		}
 
 		if ( empty( $post_metas ) ) {

--- a/src/Cache_Command.php
+++ b/src/Cache_Command.php
@@ -158,6 +158,7 @@ class Cache_Command extends WP_CLI_Command {
 		}
 
 		/** This filter is documented in wp-includes/class-wp-embed.php */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		if ( ! in_array( $post->post_type, apply_filters( 'embed_cache_oembed_types', $post_types ), true ) ) {
 			WP_CLI::warning( sprintf( "Cannot cache oEmbed results for '%s' post type", $post->post_type ) );
 

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -103,11 +103,15 @@ class Fetch_Command extends WP_CLI_Command {
 				WP_CLI::warning( "The 'limit-response-size' option only works for WordPress 4.0 onwards." );
 				// Fall through anyway...
 			}
-			add_filter( 'oembed_remote_get_args', function ( $args ) use ( $response_size_limit ) {
-				$args['limit_response_size'] = $response_size_limit;
+			add_filter(
+				'oembed_remote_get_args',
+				function ( $args ) use ( $response_size_limit ) {
+					$args['limit_response_size'] = $response_size_limit;
 
-				return $args;
-			}, PHP_INT_MAX );
+					return $args;
+				},
+				PHP_INT_MAX
+			);
 		}
 
 		// If raw, query providers directly, by-passing cache.
@@ -118,9 +122,14 @@ class Fetch_Command extends WP_CLI_Command {
 
 			// Make 'oembed_dataparse' filter a no-op so get raw unsanitized data.
 			remove_all_filters( 'oembed_dataparse' ); // Save a few cycles.
-			add_filter( 'oembed_dataparse', function ( $return, $data, $url ) {
-				return $data;
-			}, PHP_INT_MAX, 3 );
+			add_filter(
+				'oembed_dataparse',
+				function ( $return, $data, $url ) {
+					return $data;
+				},
+				PHP_INT_MAX,
+				3
+			);
 
 			// Allow `wp_filter_pre_oembed_result()` to provide local URLs (WP >= 4.5.3).
 			$data = apply_filters( 'pre_oembed_result', null, $url, $oembed_args );

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -226,9 +226,9 @@ class Fetch_Command extends WP_CLI_Command {
 	/**
 	 * Creates an XML string from a given array.
 	 *
-	 * Same as `\oembed_create_xml()` in "wp-includes\embed.php" introduced in WP 4.4.0. Polyfilled as marked private (and also to cater for older WP versions).
+	 * Same as `\_oembed_create_xml()` in "wp-includes\embed.php" introduced in WP 4.4.0. Polyfilled as marked private (and also to cater for older WP versions).
 	 *
-	 * @see oembed_create_xml()
+	 * @see _oembed_create_xml()
 	 *
 	 * @param array            $data The original oEmbed response data.
 	 * @param \SimpleXMLElement $node Optional. XML node to append the result to recursively.

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -169,7 +169,7 @@ class Fetch_Command extends WP_CLI_Command {
 		}
 
 		if ( $post_id ) {
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- the request is asking for a post id directly so need to override the global.
 			$GLOBALS['post'] = get_post( $post_id );
 			if ( null === $GLOBALS['post'] ) {
 				WP_CLI::warning( sprintf( "Post id '%s' not found.", $post_id ) );

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -199,7 +199,7 @@ class Fetch_Command extends WP_CLI_Command {
 
 			// Check providers.
 			$oembed_args['discover'] = $discover;
-			$html = wp_oembed_get( $url, $oembed_args );
+			$html                    = wp_oembed_get( $url, $oembed_args );
 
 			// `wp_oembed_get()` returns zero-length string instead of false on failure due to `_strip_newlines()` 'oembed_dataparse' filter so make sure false.
 			if ( '' === $html ) {

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -135,6 +135,7 @@ class Fetch_Command extends WP_CLI_Command {
 			);
 
 			// Allow `wp_filter_pre_oembed_result()` to provide local URLs (WP >= 4.5.3).
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			$data = apply_filters( 'pre_oembed_result', null, $url, $oembed_args );
 
 			if ( null === $data ) {

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -135,7 +135,7 @@ class Fetch_Command extends WP_CLI_Command {
 			);
 
 			// Allow `wp_filter_pre_oembed_result()` to provide local URLs (WP >= 4.5.3).
-			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WP Core hook.
 			$data = apply_filters( 'pre_oembed_result', null, $url, $oembed_args );
 
 			if ( null === $data ) {

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -75,13 +75,16 @@ class Fetch_Command extends WP_CLI_Command {
 		$post_id             = Utils\get_flag_value( $assoc_args, 'post-id' );
 		$discover            = Utils\get_flag_value( $assoc_args, 'discover' );
 		$response_size_limit = Utils\get_flag_value( $assoc_args, 'limit-response-size' );
+		$width               = Utils\get_flag_value( $assoc_args, 'width' );
+		$height              = Utils\get_flag_value( $assoc_args, 'height' );
 
 		// The `$key_suffix` used for caching is part based on serializing the attributes array without normalizing it first so need to try to replicate that.
 		$oembed_args = array();
-		if ( null !== ( $width = Utils\get_flag_value( $assoc_args, 'width' ) ) ) {
+
+		if ( null !== $width ) {
 			$oembed_args['width'] = $width; // Keep as string as if from a shortcode attribute.
 		}
-		if ( null !== ( $height = Utils\get_flag_value( $assoc_args, 'height' ) ) ) {
+		if ( null !== $height ) {
 			$oembed_args['height'] = $height; // Keep as string as if from a shortcode attribute.
 		}
 		if ( null !== $discover ) {

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -160,7 +160,7 @@ class Fetch_Command extends WP_CLI_Command {
 				if ( ! class_exists( 'SimpleXMLElement' ) ) {
 					WP_CLI::error( "The PHP extension 'SimpleXMLElement' is not available but is required for XML-formatted output." );
 				}
-				WP_CLI::log( $this->_oembed_create_xml( (array) $data ) );
+				WP_CLI::log( $this->oembed_create_xml( (array) $data ) );
 			} else {
 				WP_CLI::log( json_encode( $data ) );
 			}
@@ -226,15 +226,15 @@ class Fetch_Command extends WP_CLI_Command {
 	/**
 	 * Creates an XML string from a given array.
 	 *
-	 * Same as `\_oembed_create_xml()` in "wp-includes\embed.php" introduced in WP 4.4.0. Polyfilled as marked private (and also to cater for older WP versions).
+	 * Same as `\oembed_create_xml()` in "wp-includes\embed.php" introduced in WP 4.4.0. Polyfilled as marked private (and also to cater for older WP versions).
 	 *
-	 * @see _oembed_create_xml()
+	 * @see oembed_create_xml()
 	 *
 	 * @param array            $data The original oEmbed response data.
 	 * @param \SimpleXMLElement $node Optional. XML node to append the result to recursively.
 	 * @return string|false XML string on success, false on error.
 	 */
-	protected function _oembed_create_xml( $data, $node = null ) {
+	protected function oembed_create_xml( $data, $node = null ) {
 		if ( ! is_array( $data ) || empty( $data ) ) {
 			return false;
 		}
@@ -250,7 +250,7 @@ class Fetch_Command extends WP_CLI_Command {
 
 			if ( is_array( $value ) ) {
 				$item = $node->addChild( $key );
-				$this->_oembed_create_xml( $value, $item );
+				$this->oembed_create_xml( $value, $item );
 			} else {
 				$node->addChild( $key, esc_html( $value ) );
 			}

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -169,6 +169,7 @@ class Fetch_Command extends WP_CLI_Command {
 		}
 
 		if ( $post_id ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$GLOBALS['post'] = get_post( $post_id );
 			if ( null === $GLOBALS['post'] ) {
 				WP_CLI::warning( sprintf( "Post id '%s' not found.", $post_id ) );

--- a/src/Fetch_Command.php
+++ b/src/Fetch_Command.php
@@ -116,7 +116,7 @@ class Fetch_Command extends WP_CLI_Command {
 
 		// If raw, query providers directly, by-passing cache.
 		if ( $raw ) {
-			$oembed = new oEmbed; // Needs to be here to make sure `_wp_oembed_get_object()` defined (in "wp-includes/class-oembed.php" for WP < 4.7).
+			$oembed = new oEmbed(); // Needs to be here to make sure `_wp_oembed_get_object()` defined (in "wp-includes/class-oembed.php" for WP < 4.7).
 
 			$oembed_args['discover'] = $discover;
 

--- a/src/Handler_Command.php
+++ b/src/Handler_Command.php
@@ -71,8 +71,8 @@ class Handler_Command extends WP_CLI_Command {
 		foreach ( $wp_embed->handlers as $priority => $handlers ) {
 			foreach ( $handlers as $id => $handler ) {
 				$all_handlers[] = array(
-					'id' => $id,
-					'regex' => $handler['regex'],
+					'id'       => $id,
+					'regex'    => $handler['regex'],
 					'callback' => $handler['callback'],
 					'priority' => $priority,
 				);

--- a/src/Provider_Command.php
+++ b/src/Provider_Command.php
@@ -146,24 +146,28 @@ class Provider_Command extends WP_CLI_Command {
 				WP_CLI::warning( "The 'limit-response-size' option only works for WordPress 4.0 onwards." );
 				// Fall through anyway...
 			}
-			add_filter( 'oembed_remote_get_args', function ( $args ) use ( $response_size_limit ) {
-				$args['limit_response_size'] = $response_size_limit;
-
-				return $args;
-			} );
+			add_filter(
+				'oembed_remote_get_args',
+				function ( $args ) use ( $response_size_limit ) {
+					$args['limit_response_size'] = $response_size_limit;
+					return $args;
+				}
+			);
 		}
 
 		if ( $link_type ) {
 			// Filter discovery response.
-			add_filter( 'oembed_linktypes', function ( $linktypes ) use ( $link_type ) {
-				foreach ( $linktypes as $mime_type => $linktype_format ) {
-					if ( $link_type !== $linktype_format ) {
-						unset( $linktypes[ $mime_type ] );
+			add_filter(
+				'oembed_linktypes',
+				function ( $linktypes ) use ( $link_type ) {
+					foreach ( $linktypes as $mime_type => $linktype_format ) {
+						if ( $link_type !== $linktype_format ) {
+							unset( $linktypes[ $mime_type ] );
+						}
 					}
+					return $linktypes;
 				}
-
-				return $linktypes;
-			} );
+			);
 		}
 
 		$oembed_args = array(

--- a/src/Provider_Command.php
+++ b/src/Provider_Command.php
@@ -72,7 +72,7 @@ class Provider_Command extends WP_CLI_Command {
 
 		$providers = array();
 
-		foreach (  (array) $oembed->providers as $matchmask => $data ) {
+		foreach ( (array) $oembed->providers as $matchmask => $data ) {
 			list( $providerurl, $regex ) = $data;
 
 			// Turn the asterisk-type provider URLs into regex
@@ -84,7 +84,7 @@ class Provider_Command extends WP_CLI_Command {
 			$providers[] = array(
 				'format'   => $matchmask,
 				'endpoint' => $providerurl,
-				'regex' => $regex ? '1' : '0',
+				'regex'    => $regex ? '1' : '0',
 			);
 		}
 

--- a/src/Provider_Command.php
+++ b/src/Provider_Command.php
@@ -66,7 +66,7 @@ class Provider_Command extends WP_CLI_Command {
 	 */
 	public function list_providers( $args, $assoc_args ) {
 
-		$oembed = new oEmbed;
+		$oembed = new oEmbed();
 
 		$force_regex = Utils\get_flag_value( $assoc_args, 'force-regex' );
 
@@ -123,7 +123,7 @@ class Provider_Command extends WP_CLI_Command {
 	 * @subcommand match
 	 */
 	public function match_provider( $args, $assoc_args ) {
-		$oembed = new oEmbed;
+		$oembed = new oEmbed();
 
 		$url                 = $args[0];
 		$discover            = \WP_CLI\Utils\get_flag_value( $assoc_args, 'discover', true );

--- a/src/oEmbed.php
+++ b/src/oEmbed.php
@@ -8,8 +8,10 @@ if ( ! class_exists( '\WP_oEmbed' ) ) {
 
 /**
  * Polyfill for older WP versions.
+ *
+ * phpcs:disable PEAR.NamingConventions.ValidClassName.StartWithCapital -- this is purposefully using a lowercase letter for back compat reasons.
  */
-class OEmbed extends \WP_oEmbed {
+class oEmbed extends \WP_oEmbed {
 
 	/**
 	 * Takes a URL and returns the corresponding oEmbed provider's URL, if there is one.

--- a/src/oEmbed.php
+++ b/src/oEmbed.php
@@ -8,8 +8,6 @@ if ( ! class_exists( '\WP_oEmbed' ) ) {
 
 /**
  * Polyfill for older WP versions.
- *
- * phpcs:disable PEAR.NamingConventions.ValidClassName.StartWithCapital -- this is purposefully using a lowercase letter for back compat reasons.
  */
 class oEmbed extends \WP_oEmbed {
 

--- a/src/oEmbed.php
+++ b/src/oEmbed.php
@@ -8,6 +8,8 @@ if ( ! class_exists( '\WP_oEmbed' ) ) {
 
 /**
  * Polyfill for older WP versions.
+ *
+ * phpcs:disable PEAR.NamingConventions.ValidClassName.StartWithCapital -- this is purposefully using a lowercase letter for back compat reasons.
  */
 class oEmbed extends \WP_oEmbed {
 

--- a/src/oEmbed.php
+++ b/src/oEmbed.php
@@ -8,10 +8,8 @@ if ( ! class_exists( '\WP_oEmbed' ) ) {
 
 /**
  * Polyfill for older WP versions.
- *
- * phpcs:disable PEAR.NamingConventions.ValidClassName.StartWithCapital -- this is purposefully using a lowercase letter for back compat reasons.
  */
-class oEmbed extends \WP_oEmbed {
+class OEmbed extends \WP_oEmbed {
 
 	/**
 	 * Takes a URL and returns the corresponding oEmbed provider's URL, if there is one.


### PR DESCRIPTION
This applies some changes to bring the code in line with the new WPCliCS ruleset.

There are only 2 remaining `WARNING`s in this package at the time when I open this PR. Some advice about if I should silence the warnings. The 2 items left are:

```
williampatton@williampatton-ws:~/wd-sw/embed-command$ phpcs --standard=WPCliCS src/*

FILE: /home/williampatton/wd-sw/embed-command/src/Cache_Command.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------
 116 | WARNING | serialize() found. Serialized data has known vulnerability
     |         | problems with Object Injection. JSON is generally a better
     |         | approach for serializing data. See
     |         | https://www.owasp.org/index.php/PHP_Object_Injection
--------------------------------------------------------------------------------


FILE: /home/williampatton/wd-sw/embed-command/src/Fetch_Command.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------
 237 | WARNING | Method name "_oembed_create_xml" should not be prefixed with
     |         | an underscore to indicate visibility
--------------------------------------------------------------------------------

Time: 341ms; Memory: 14MB
```

The `_oembed_create_xml` method I guess I should silence but what about the use of `serialize()`?

This is part 2 of #45 

Related https://github.com/wp-cli/wp-cli/issues/5179