### PR TITLE
Replace asciinema.org in tests

### DIFF
--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -54,7 +54,7 @@ Feature: Manage oEmbed cache.
 
     # Unknown provider requiring discovery but not returning iframe so would be sanitized for WP >= 4.4 without 'skip-sanitization' option.
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed fetch https://asciinema.org/a/140798 --skip-sanitization`
+    When I try `wp embed fetch https://view.ceros.com/ceros/new-experience-3/p/1 --skip-sanitization`
     Then the return code should be 0
     And STDERR should not contain:
       """
@@ -62,7 +62,7 @@ Feature: Manage oEmbed cache.
       """
     And STDOUT should contain:
       """
-      asciinema.org/
+      ceros.com/
       """
     And STDOUT should contain:
       """
@@ -76,10 +76,10 @@ Feature: Manage oEmbed cache.
   # WP 4.9 always returns clickable link even for sanitized oEmbed responses.
   @require-wp-4.9
   Scenario: Get HTML embed code for a given URL that requires discovery and is sanitized
-    When I run `wp embed fetch https://asciinema.org/a/140798`
+    When I run `wp embed fetch https://view.ceros.com/ceros/new-experience-3/p/1`
     Then STDOUT should contain:
       """
-      asciinema.org/
+      ceros.com/
       """
     And STDOUT should contain:
       """
@@ -89,7 +89,7 @@ Feature: Manage oEmbed cache.
   # `wp_filter_oembed_result` filter introduced WP 4.4 which sanitizes oEmbed responses that don't include an iframe.
   @less-than-wp-4.9 @require-wp-4.4
   Scenario: Get HTML embed code for a given URL that requires discovery and is sanitized
-    When I try `wp embed fetch https://asciinema.org/a/140798`
+    When I try `wp embed fetch https://view.ceros.com/ceros/new-experience-3/p/1`
     Then the return code should be 1
     And STDERR should be:
       """
@@ -101,7 +101,7 @@ Feature: Manage oEmbed cache.
   @less-than-wp-4.4 @require-wp-4.0
   Scenario: Get HTML embed code for a given URL that requires discovery and is sanitized
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed fetch https://asciinema.org/a/140798`
+    When I try `wp embed fetch https://view.ceros.com/ceros/new-experience-3/p/1`
     Then the return code should be 0
     And STDERR should not contain:
       """
@@ -109,7 +109,7 @@ Feature: Manage oEmbed cache.
       """
     And STDOUT should contain:
       """
-      asciinema.org/
+      ceros.com/
       """
 
   @require-wp-4.0
@@ -130,7 +130,7 @@ Feature: Manage oEmbed cache.
 
     # Raw requests are not sanitized.
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed fetch https://asciinema.org/a/140798 --raw`
+    When I try `wp embed fetch https://view.ceros.com/creative-services/sdk --raw`
     Then the return code should be 0
     And STDERR should not contain:
       """
@@ -138,7 +138,7 @@ Feature: Manage oEmbed cache.
       """
     And STDOUT should contain:
       """
-      asciinema.org
+      ceros.com
       """
 
   @require-wp-4.0

--- a/features/provider.feature
+++ b/features/provider.feature
@@ -138,7 +138,7 @@ Feature: Manage oEmbed providers.
 
     # Provider requiring discovery
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed provider match https://asciinema.org/a/140798`
+    When I try `wp embed provider match https://audio.com/audio-com/collections/ambient-focus`
     And save STDOUT as {DEFAULT_STDOUT}
     Then the return code should be 0
     And STDERR should not contain:
@@ -147,7 +147,7 @@ Feature: Manage oEmbed providers.
       """
     And STDOUT should contain:
       """
-      asciinema.org/
+      audio.com/
       """
     And STDOUT should contain:
       """
@@ -159,7 +159,7 @@ Feature: Manage oEmbed providers.
       """
 
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed provider match https://asciinema.org/a/140798 --link-type=json`
+    When I try `wp embed provider match https://audio.com/audio-com/collections/ambient-focus --link-type=json`
     Then the return code should be 0
     And STDERR should not contain:
       """
@@ -171,7 +171,7 @@ Feature: Manage oEmbed providers.
       """
 
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed provider match https://asciinema.org/a/140798 --link-type=xml`
+    When I try `wp embed provider match https://audio.com/audio-com/collections/ambient-focus --link-type=xml`
     Then the return code should be 0
     And STDERR should not contain:
       """
@@ -183,7 +183,7 @@ Feature: Manage oEmbed providers.
       """
     And STDOUT should contain:
       """
-      asciinema.org/
+      audio.com/
       """
     And STDOUT should contain:
       """
@@ -197,11 +197,11 @@ Feature: Manage oEmbed providers.
   # Depends on `oembed_remote_get_args` filter introduced in WP 4.0 https://core.trac.wordpress.org/ticket/23442
   @require-wp-4.0
   Scenario: Discover a provider with limited response size
-    When I run `wp embed provider match https://asciinema.org/a/140798`
+    When I run `wp embed provider match https://audio.com/audio-com/collections/ambient-focus`
     And save STDOUT as {DEFAULT_STDOUT}
 
     # Response limit too small
-    When I try `wp embed provider match https://asciinema.org/a/140798 --limit-response-size=10`
+    When I try `wp embed provider match https://audio.com/audio-com/collections/ambient-focus --limit-response-size=10`
     Then the return code should be 1
     And STDERR should be:
       """
@@ -209,7 +209,7 @@ Feature: Manage oEmbed providers.
       """
 
     # Response limit big enough
-    When I run `wp embed provider match https://asciinema.org/a/140798 --limit-response-size=50000`
+    When I run `wp embed provider match https://audio.com/audio-com/collections/ambient-focus --limit-response-size=50000`
     Then STDOUT should be:
       """
       {DEFAULT_STDOUT}
@@ -244,7 +244,7 @@ Feature: Manage oEmbed providers.
 
   @require-wp-4.0
   Scenario: Only match an oEmbed provider if discover
-    When I try `wp embed provider match https://asciinema.org/a/140798 --no-discover`
+    When I try `wp embed provider match https://audio.com/audio-com/collections/ambient-focus --no-discover`
     Then the return code should be 1
     And STDERR should be:
       """
@@ -253,7 +253,7 @@ Feature: Manage oEmbed providers.
     And STDOUT should be empty
 
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed provider match https://asciinema.org/a/140798`
+    When I try `wp embed provider match https://audio.com/audio-com/collections/ambient-focus`
     Then the return code should be 0
     And STDERR should not contain:
       """
@@ -261,7 +261,7 @@ Feature: Manage oEmbed providers.
       """
     And STDOUT should contain:
       """
-      asciinema.org/
+      audio.com/
       """
     And STDOUT should contain:
       """
@@ -269,7 +269,7 @@ Feature: Manage oEmbed providers.
       """
 
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed provider match https://asciinema.org/a/140798 --discover`
+    When I try `wp embed provider match https://audio.com/audio-com/collections/ambient-focus --discover`
     Then the return code should be 0
     And STDERR should not contain:
       """
@@ -277,7 +277,7 @@ Feature: Manage oEmbed providers.
       """
     And STDOUT should contain:
       """
-      asciinema.org/
+     audio.com/
       """
 
   Scenario: Incompatible or wrong options

--- a/features/provider.feature
+++ b/features/provider.feature
@@ -265,7 +265,7 @@ Feature: Manage oEmbed providers.
       """
     And STDOUT should contain:
       """
-      140798
+      collection
       """
 
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.


### PR DESCRIPTION
The site no longer supports oEmbed.

Replaced it with some other sites I found through https://github.com/iamcal/oembed

See https://github.com/wp-cli/wp-cli/issues/5810