### PR TITLE
Fix tests

### DIFF
--- a/features/fetch.feature
+++ b/features/fetch.feature
@@ -54,7 +54,7 @@ Feature: Manage oEmbed cache.
 
     # Unknown provider requiring discovery but not returning iframe so would be sanitized for WP >= 4.4 without 'skip-sanitization' option.
     # Old versions of WP_oEmbed can trigger PHP "Only variables should be passed by reference" notices on discover so use "try" to cater for these.
-    When I try `wp embed fetch https://view.ceros.com/ceros/new-experience-3/p/1 --skip-sanitization`
+    When I try `wp embed fetch https://app.ex.co/stories/item/8fb2343f-fa5d-48d4-8723-f8b5d51cc1a9 --skip-sanitization`
     Then the return code should be 0
     And STDERR should not contain:
       """
@@ -62,7 +62,7 @@ Feature: Manage oEmbed cache.
       """
     And STDOUT should contain:
       """
-      ceros.com/
+      app.ex.co/
       """
     And STDOUT should contain:
       """
@@ -72,14 +72,18 @@ Feature: Manage oEmbed cache.
       """
       <iframe
      """
+    And STDOUT should not contain:
+      """
+      <script
+     """
 
   # WP 4.9 always returns clickable link even for sanitized oEmbed responses.
   @require-wp-4.9
   Scenario: Get HTML embed code for a given URL that requires discovery and is sanitized
-    When I run `wp embed fetch https://view.ceros.com/ceros/new-experience-3/p/1`
+    When I run `wp embed fetch https://app.ex.co/stories/item/8fb2343f-fa5d-48d4-8723-f8b5d51cc1a9`
     Then STDOUT should contain:
       """
-      ceros.com/
+      app.ex.co/
       """
     And STDOUT should contain:
       """


### PR DESCRIPTION
Looks like one of the providers used in #71 changed their oEmbed output since then.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
